### PR TITLE
[Parser] Add optional procedure in let binding

### DIFF
--- a/code/src/main/scala/sai/direct/large/parser/LargeSchemeParser.scala
+++ b/code/src/main/scala/sai/direct/large/parser/LargeSchemeParser.scala
@@ -22,9 +22,12 @@ trait LargeSchemeParserTrait extends SchemeTokenParser {
     case binds ~ body => Let(binds, body)
   }
 
-  // def letfun: Parser[Let] = LPAREN ~> LET ~> IDENT ~ (LPAREN ~> bind.+ <~ RPAREN) ~ expr <~ RPAREN ^^ {
-  //   case ident ~ binds ~ body => Let(Bind(ident, Lam(
-  // }
+  def letproc: Parser[Let] = LPAREN ~> LET ~> IDENT ~ (LPAREN ~> bind.+ <~ RPAREN) ~ expr <~ RPAREN ^^ {
+    case ident ~ binds ~ body => 
+      val args = binds map { case Bind(id, _) => id }
+      val initvals = binds map { case Bind(_, initv) => initv }
+      Let(List(Bind(ident, Lam(args, body))), App(Var(ident), initvals))
+  }
 
   def letstar: Parser[LetStar] = LPAREN ~> LETSTAR ~> (LPAREN ~> bind.+ <~ RPAREN) ~ expr <~ RPAREN ^^ {
     case binds ~ body => LetStar(binds, body)
@@ -62,7 +65,7 @@ trait LargeSchemeParserTrait extends SchemeTokenParser {
     case branches => Cond(branches)
   }
 
-  def expr: Parser[Expr] = intlit | boollit | listsugar | vecsugar | variable | lam | let | letstar | letrec | ifthel | cond | app
+  def expr: Parser[Expr] = intlit | boollit | listsugar | vecsugar | variable | lam | let | letproc | letstar | letrec | ifthel | cond | app
 
   def define: Parser[Define] = LPAREN ~> DEF ~> IDENT ~ expr <~ RPAREN ^^ {
     case id ~ e => Define(id, e)


### PR DESCRIPTION
Expand the let with optional procedure syntax to the AST as defined in Racket. 

As in https://docs.racket-lang.org/reference/let.html#%28form._%28%28lib._racket%2Fprivate%2Fletstx-scheme..rkt%29._let%29%29