### PR TITLE
impure backend impl contd.

### DIFF
--- a/dev-clean/benchmarks/llvm/power.c
+++ b/dev-clean/benchmarks/llvm/power.c
@@ -11,5 +11,5 @@ int power(int x, int n) {
 }
 
 int main() {
-  return power(3, 3);
+  return power(2, 15);
 }

--- a/dev-clean/headers/llsc_external.hpp
+++ b/dev-clean/headers/llsc_external.hpp
@@ -37,7 +37,7 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> malloc(SS state, immer::flex_ve
 inline immer::flex_vector<std::pair<SS, PtrVal>> realloc(SS state, immer::flex_vector<PtrVal> args) {
   Addr src = proj_LocV(args.at(0));
   IntData bytes = proj_IntV(args.at(1));
-  
+
   auto emptyMem = immer::flex_vector<PtrVal>(bytes, make_IntV(0));
   std::cout << "realloc size: " << emptyMem.size() << std::endl;
   PtrVal memLoc = make_LocV(state.heap_size(), LocV::kHeap, bytes);
@@ -50,25 +50,26 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> realloc(SS state, immer::flex_v
   return immer::flex_vector<std::pair<SS, PtrVal>>{{res, memLoc}};
 }
 
-inline void handle_pc(const std::set<PtrVal>& pc) {
+inline void handle_pc(immer::set<SExpr> pc) {
 
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> llsc_assert(SS state, immer::flex_vector<PtrVal> args) {
-  auto &pc = state.getPC();
-  handle_pc(pc);
+  // XXX(GW): temporarily commented, should invoke Checker and generate test case properly?
+  //immer::set<SExpr> pc = state.getPC();
+  //handle_pc(pc);
   return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(0)}};
 }
 
-inline immer::flex_vector<std::pair<SS, PtrVal>> make_symbolic(SS& state, immer::flex_vector<PtrVal> args) {
+inline immer::flex_vector<std::pair<SS, PtrVal>> make_symbolic(SS state, immer::flex_vector<PtrVal> args) {
   PtrVal make_loc = args.at(0);
   IntData len = proj_IntV(args.at(1));
-  SS res = std::move(state);
+  SS res = state;
   //std::cout << "sym array size: " << proj_LocV_size(make_loc) << "\n";
   for (int i = 0; i < len; i++) {
-    res.update(make_LocV_inc(make_loc, i), make_SymV("x" + std::to_string(var_name++)));
+    res = res.update(make_LocV_inc(make_loc, i), make_SymV("x" + std::to_string(var_name++)));
   }
-  return immer::flex_vector<std::pair<SS, PtrVal>>{{std::move(res), make_IntV(0)}};
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, make_IntV(0)}};
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> __assert_fail(SS state, immer::flex_vector<PtrVal> args) {

--- a/dev-clean/headers/llsc_external.hpp
+++ b/dev-clean/headers/llsc_external.hpp
@@ -50,12 +50,12 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> realloc(SS state, immer::flex_v
   return immer::flex_vector<std::pair<SS, PtrVal>>{{res, memLoc}};
 }
 
-inline void handle_pc(immer::set<SExpr> pc) {
+inline void handle_pc(const std::set<PtrVal>& pc) {
 
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> llsc_assert(SS state, immer::flex_vector<PtrVal> args) {
-  immer::set<SExpr> pc = state.getPC();
+  auto &pc = state.getPC();
   handle_pc(pc);
   return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(0)}};
 }

--- a/dev-clean/headers/llsc_external.hpp
+++ b/dev-clean/headers/llsc_external.hpp
@@ -60,15 +60,15 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llsc_assert(SS state, immer::fl
   return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(0)}};
 }
 
-inline immer::flex_vector<std::pair<SS, PtrVal>> make_symbolic(SS state, immer::flex_vector<PtrVal> args) {
+inline immer::flex_vector<std::pair<SS, PtrVal>> make_symbolic(SS& state, immer::flex_vector<PtrVal> args) {
   PtrVal make_loc = args.at(0);
   IntData len = proj_IntV(args.at(1));
-  SS res = state;
+  SS res = std::move(state);
   //std::cout << "sym array size: " << proj_LocV_size(make_loc) << "\n";
   for (int i = 0; i < len; i++) {
-    res = res.update(make_LocV_inc(make_loc, i), make_SymV("x" + std::to_string(var_name++)));
+    res.update(make_LocV_inc(make_loc, i), make_SymV("x" + std::to_string(var_name++)));
   }
-  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, make_IntV(0)}};
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{std::move(res), make_IntV(0)}};
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> __assert_fail(SS state, immer::flex_vector<PtrVal> args) {

--- a/dev-clean/headers/llsc_imp.hpp
+++ b/dev-clean/headers/llsc_imp.hpp
@@ -614,10 +614,11 @@ class SS {
 #endif
 
   public:
-    SS(Mem heap, Stack stack, PC pc, BlockLabel bb) : heap(std::move(heap)), stack(std::move(stack)), pc(std::move(pc)), bb(bb) {}
-    SS copy() {
-      return *this;
-    }
+    SS(Mem heap, Stack stack, PC pc, BlockLabel bb) :
+      heap(std::move(heap)), stack(std::move(stack)), pc(std::move(pc)), bb(bb) {}
+    SS(immer::flex_vector<PtrVal> heap, Stack stack, PC pc, BlockLabel bb) :
+      heap(std::move(std::vector(heap.begin(), heap.end()))), stack(std::move(stack)), pc(std::move(pc)), bb(bb) {}
+    SS copy() { return *this; }
     PtrVal env_lookup(Id id) { return stack.lookup_id(id); }
     size_t heap_size() { return heap.size(); }
     size_t stack_size() { return stack.mem_size(); }

--- a/dev-clean/headers/llsc_imp.hpp
+++ b/dev-clean/headers/llsc_imp.hpp
@@ -461,7 +461,7 @@ class PreMem {
     size_t size() { return mem.size(); }
     V at(size_t idx) { return mem.at(idx); }
     PreMem&& update(size_t idx, V val) {
-      mem[idx] = val;
+      mem.at(idx) = val;
       return std::move(*this);
     }
     PreMem&& append(V val) {
@@ -531,8 +531,7 @@ class Stack {
       return std::move(*this);
     }
     Stack&& push() {
-      env.push_back(Frame());
-      return std::move(*this);
+      return push(Frame());
     }
     Stack&& push(Frame f) {
       env.push_back(std::move(f));
@@ -571,7 +570,7 @@ class Stack {
       mem.update(idx, val);
       return std::move(*this);
     }
-    Stack alloc(size_t size) {
+    Stack&& alloc(size_t size) {
       mem.alloc(size);
       return std::move(*this);
     }

--- a/dev-clean/headers/llsc_imp.hpp
+++ b/dev-clean/headers/llsc_imp.hpp
@@ -505,12 +505,12 @@ class Frame {
     size_t size() { return env.size(); }
     PtrVal lookup_id(Id id) const { return env.at(id); }
     Frame&& assign(Id id, PtrVal v) {
-      env.emplace(id, v);
+      env.insert_or_assign(id, v);
       return std::move(*this);
     }
     Frame&& assign_seq(const std::vector<Id>& ids, const std::vector<PtrVal>& vals) {
       for (size_t i = 0; i < ids.size(); i++) {
-        env.emplace(ids.at(i), vals.at(i));
+        env.insert_or_assign(ids.at(i), vals.at(i));
       }
       return std::move(*this);
     }

--- a/dev-clean/headers/llsc_imp_external.hpp
+++ b/dev-clean/headers/llsc_imp_external.hpp
@@ -1,4 +1,4 @@
-#include <llsc.hpp>
+#include <llsc_imp.hpp>
 
 /* temp util functions */
 inline immer::flex_vector<SExpr> set_to_list(immer::set<SExpr> s) {

--- a/dev-clean/headers/llsc_imp_external.hpp
+++ b/dev-clean/headers/llsc_imp_external.hpp
@@ -1,0 +1,79 @@
+#include <llsc.hpp>
+
+/* temp util functions */
+inline immer::flex_vector<SExpr> set_to_list(immer::set<SExpr> s) {
+  auto res = immer::flex_vector<SExpr>{};
+  for (auto x : s) {
+    res = res.push_back(x);
+  }
+  return res;
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> sym_print(SS state, immer::flex_vector<PtrVal> args) {
+  PtrVal x = args.at(0);
+  if (std::dynamic_pointer_cast<FloatV>(x)) {
+    std::cout << "FloatV" << std::dynamic_pointer_cast<FloatV>(x)->f << ")\n";
+  } else if (std::dynamic_pointer_cast<IntV>(x)) {
+    std::cout << "IntV(" << std::dynamic_pointer_cast<IntV>(x)->i << ")\n";
+  } else if (std::dynamic_pointer_cast<LocV>(x)){
+    ABORT("Unimplemented LOCV");
+  } else if ( x == nullptr ){
+    ABORT("Unimplemented nullptr");
+  }
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(0)}};
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> noop(SS state, immer::flex_vector<PtrVal> args) {
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(0)}};
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> malloc(SS state, immer::flex_vector<PtrVal> args) {
+  IntData bytes = proj_IntV(args.at(0));
+  auto emptyMem = immer::flex_vector<PtrVal>(bytes, make_IntV(0));
+  PtrVal memLoc = make_LocV(state.heap_size(), LocV::kHeap, bytes);
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{state.heap_append(emptyMem), memLoc}};
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> realloc(SS state, immer::flex_vector<PtrVal> args) {
+  Addr src = proj_LocV(args.at(0));
+  IntData bytes = proj_IntV(args.at(1));
+
+  auto emptyMem = immer::flex_vector<PtrVal>(bytes, make_IntV(0));
+  std::cout << "realloc size: " << emptyMem.size() << std::endl;
+  PtrVal memLoc = make_LocV(state.heap_size(), LocV::kHeap, bytes);
+  IntData prevBytes = proj_LocV_size(args.at(0));
+  std::cout << "prev size: " << prevBytes << std::endl;
+  SS res = state.heap_append(emptyMem);
+  for (int i = 0; i < prevBytes; i++) {
+    res = res.update(make_LocV_inc(memLoc, i), res.heap_lookup(src + i));
+  }
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, memLoc}};
+}
+
+inline void handle_pc(const std::set<PtrVal>& pc) {
+
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> llsc_assert(SS state, immer::flex_vector<PtrVal> args) {
+  // XXX(GW): temporarily commented, should invoke Checker and generate test case properly?
+  // auto &pc = state.getPC();
+  // handle_pc(pc);
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(0)}};
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> make_symbolic(SS& state, immer::flex_vector<PtrVal> args) {
+  PtrVal make_loc = args.at(0);
+  IntData len = proj_IntV(args.at(1));
+  SS res = std::move(state);
+  //std::cout << "sym array size: " << proj_LocV_size(make_loc) << "\n";
+  for (int i = 0; i < len; i++) {
+    res.update(make_LocV_inc(make_loc, i), make_SymV("x" + std::to_string(var_name++)));
+  }
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{std::move(res), make_IntV(0)}};
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> __assert_fail(SS state, immer::flex_vector<PtrVal> args) {
+  // TODO get real argument string
+  // std::cout << "Fail: Calling to __assert_fail" << std::endl;
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(0)}};
+}

--- a/dev-clean/headers/llsc_imp_intrinsics.hpp
+++ b/dev-clean/headers/llsc_imp_intrinsics.hpp
@@ -1,4 +1,4 @@
-#include <llsc.hpp>
+#include <llsc_imp.hpp>
 
 static PtrVal IntV0 = make_IntV(0);
 
@@ -11,7 +11,7 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memcpy(SS& state, immer::f
   Addr dest_addr = proj_LocV(dest);
   Addr src_addr = proj_LocV(src);
   IntData bytes_int = proj_IntV(bytes);
-  
+
   // Optmize
   // flex_vector_transient
   for (int i = 0; i < bytes_int; i++) {
@@ -27,7 +27,7 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memmove(SS state, immer::f
 
   SS res = state;
   IntData bytes_int = proj_IntV(bytes);
-  
+
   // Optmize
   // flex_vector_transient
   auto temp_mem = immer::flex_vector<PtrVal>{};
@@ -51,7 +51,7 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memset(SS state, immer::fl
   // what could be other set value?
   int setInt = 0;
   IntData bytes_int = proj_IntV(bytes);
-  
+
   // Optmize
   // flex_vector_transient
   for (int i = 0; i < bytes_int; i++) {

--- a/dev-clean/headers/llsc_imp_intrinsics.hpp
+++ b/dev-clean/headers/llsc_imp_intrinsics.hpp
@@ -1,0 +1,76 @@
+#include <llsc.hpp>
+
+static PtrVal IntV0 = make_IntV(0);
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memcpy(SS& state, immer::flex_vector<PtrVal> args) {
+  PtrVal dest = args.at(0);
+  PtrVal src = args.at(1);
+  PtrVal bytes = args.at(2);
+
+  SS res = std::move(state);
+  Addr dest_addr = proj_LocV(dest);
+  Addr src_addr = proj_LocV(src);
+  IntData bytes_int = proj_IntV(bytes);
+  
+  // Optmize
+  // flex_vector_transient
+  for (int i = 0; i < bytes_int; i++) {
+    res.update(make_LocV_inc(dest, i), res.at(make_LocV_inc(src, i)));
+  }
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{std::move(res), IntV0}};
+}
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memmove(SS state, immer::flex_vector<PtrVal> args) {
+  PtrVal dest = args.at(0);
+  PtrVal src = args.at(1);
+  PtrVal bytes = args.at(2);
+
+  SS res = state;
+  IntData bytes_int = proj_IntV(bytes);
+  
+  // Optmize
+  // flex_vector_transient
+  auto temp_mem = immer::flex_vector<PtrVal>{};
+  for (int i = 0; i < bytes_int; i++) {
+    temp_mem = temp_mem.push_back(res.at(make_LocV_inc(src, i)));
+  }
+  for (int i = 0; i < bytes_int; i++) {
+    res = res.update(make_LocV_inc(dest, i), temp_mem.at(i));
+  }
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, IntV0}};
+}
+
+
+inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memset(SS state, immer::flex_vector<PtrVal> args) {
+  PtrVal dest = args.at(0);
+  PtrVal seti8 = args.at(1);
+  PtrVal bytes = args.at(2);
+
+  SS res = state;
+  Addr dest_addr = proj_LocV(dest);
+  // what could be other set value?
+  int setInt = 0;
+  IntData bytes_int = proj_IntV(bytes);
+  
+  // Optmize
+  // flex_vector_transient
+  for (int i = 0; i < bytes_int; i++) {
+    res = res.update(make_LocV_inc(dest, i), IntV0);
+  }
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, IntV0}};
+}
+
+// args 0: LocV to {i32, i32, i8*, i8*}
+// in memory {4, 4, 8, 8}
+inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_va_start(SS state, immer::flex_vector<PtrVal> args) {
+  PtrVal va_list = args.at(0);
+  PtrVal va_arg = state.getVarargLoc();
+  SS res = state;
+
+  res = res.update(make_LocV_inc(va_list, 0), IntV0);
+  res = res.update(make_LocV_inc(va_list, 4), IntV0);
+  res = res.update(make_LocV_inc(va_list, 8), make_LocV_inc(va_arg, 40));
+  res = res.update(make_LocV_inc(va_list, 16), va_arg);
+
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, IntV0}};
+}

--- a/dev-clean/headers/llsc_intrinsics.hpp
+++ b/dev-clean/headers/llsc_intrinsics.hpp
@@ -2,22 +2,22 @@
 
 static PtrVal IntV0 = make_IntV(0);
 
-inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memcpy(SS& state, immer::flex_vector<PtrVal> args) {
+inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memcpy(SS state, immer::flex_vector<PtrVal> args) {
   PtrVal dest = args.at(0);
   PtrVal src = args.at(1);
   PtrVal bytes = args.at(2);
 
-  SS res = std::move(state);
+  SS res = state;
   Addr dest_addr = proj_LocV(dest);
   Addr src_addr = proj_LocV(src);
   IntData bytes_int = proj_IntV(bytes);
-  
+
   // Optmize
   // flex_vector_transient
   for (int i = 0; i < bytes_int; i++) {
-    res.update(make_LocV_inc(dest, i), res.at(make_LocV_inc(src, i)));
+    res = res.update(make_LocV_inc(dest, i), res.at(make_LocV_inc(src, i)));
   }
-  return immer::flex_vector<std::pair<SS, PtrVal>>{{std::move(res), IntV0}};
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, IntV0}};
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memmove(SS state, immer::flex_vector<PtrVal> args) {
@@ -27,7 +27,7 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memmove(SS state, immer::f
 
   SS res = state;
   IntData bytes_int = proj_IntV(bytes);
-  
+
   // Optmize
   // flex_vector_transient
   auto temp_mem = immer::flex_vector<PtrVal>{};
@@ -51,7 +51,7 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memset(SS state, immer::fl
   // what could be other set value?
   int setInt = 0;
   IntData bytes_int = proj_IntV(bytes);
-  
+
   // Optmize
   // flex_vector_transient
   for (int i = 0; i < bytes_int; i++) {

--- a/dev-clean/headers/llsc_intrinsics.hpp
+++ b/dev-clean/headers/llsc_intrinsics.hpp
@@ -2,12 +2,12 @@
 
 static PtrVal IntV0 = make_IntV(0);
 
-inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memcpy(SS state, immer::flex_vector<PtrVal> args) {
+inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memcpy(SS& state, immer::flex_vector<PtrVal> args) {
   PtrVal dest = args.at(0);
   PtrVal src = args.at(1);
   PtrVal bytes = args.at(2);
 
-  SS res = state;
+  SS res = std::move(state);
   Addr dest_addr = proj_LocV(dest);
   Addr src_addr = proj_LocV(src);
   IntData bytes_int = proj_IntV(bytes);
@@ -15,9 +15,9 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memcpy(SS state, immer::fl
   // Optmize
   // flex_vector_transient
   for (int i = 0; i < bytes_int; i++) {
-    res = res.update(make_LocV_inc(dest, i), res.at(make_LocV_inc(src, i)));
+    res.update(make_LocV_inc(dest, i), res.at(make_LocV_inc(src, i)));
   }
-  return immer::flex_vector<std::pair<SS, PtrVal>>{{res, IntV0}};
+  return immer::flex_vector<std::pair<SS, PtrVal>>{{std::move(res), IntV0}};
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> llvm_memmove(SS state, immer::flex_vector<PtrVal> args) {

--- a/dev-clean/src/main/scala/sai/llscImp/Codegen.scala
+++ b/dev-clean/src/main/scala/sai/llscImp/Codegen.scala
@@ -12,8 +12,8 @@ import java.io.FileOutputStream
 
 trait SymStagedLLVMGen extends CppSAICodeGenBase {
   registerHeader("./headers", "<llsc_imp.hpp>")
-  registerHeader("./headers", "<llsc_intrinsics.hpp>")
-  registerHeader("./headers", "<llsc_external.hpp>")
+  registerHeader("./headers", "<llsc_imp_intrinsics.hpp>")
+  registerHeader("./headers", "<llsc_imp_external.hpp>")
 
   registerHeader("<stp/c_interface.h>")
   registerHeader("./headers", "<stp_handle.hpp>")

--- a/dev-clean/src/main/scala/sai/llscImp/Driver.scala
+++ b/dev-clean/src/main/scala/sai/llscImp/Driver.scala
@@ -138,12 +138,14 @@ object RunLLSC {
     }
     //  */
 
-    //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.branch, "branch", "@f", 2)
+    sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.branch, "branch", "@f", 2)
     //runLLSC(sai.llvm.Benchmarks.branch, "branchImp", "@f", 2)
     //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.maze, "maze", "@main", 0)
     //runLLSC(sai.llvm.Benchmarks.maze, "mazeImp", "@main", 0)
-    sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.power, "power", "@main", 0)
-    runLLSC(sai.llvm.Benchmarks.power, "powerImp", "@main", 0)
+    //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.power, "powerPure", "@main", 0)
+    //runLLSC(sai.llvm.Benchmarks.power, "powerImp", "@main", 0)
+    //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.mergesort, "mergePure", "@main", 0)
+    //runLLSC(sai.llvm.Benchmarks.mergesort, "mergeImp", "@main", 0)
 
   }
 }

--- a/dev-clean/src/main/scala/sai/llscImp/Driver.scala
+++ b/dev-clean/src/main/scala/sai/llscImp/Driver.scala
@@ -138,14 +138,13 @@ object RunLLSC {
     }
     //  */
 
-    sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.branch, "branch", "@f", 2)
+    //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.branch, "branch", "@f", 2)
     //runLLSC(sai.llvm.Benchmarks.branch, "branchImp", "@f", 2)
     //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.maze, "maze", "@main", 0)
     //runLLSC(sai.llvm.Benchmarks.maze, "mazeImp", "@main", 0)
     //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.power, "powerPure", "@main", 0)
     //runLLSC(sai.llvm.Benchmarks.power, "powerImp", "@main", 0)
-    //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.mergesort, "mergePure", "@main", 0)
-    //runLLSC(sai.llvm.Benchmarks.mergesort, "mergeImp", "@main", 0)
-
+    sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.mergesort, "mergePure", "@main", 0)
+    runLLSC(sai.llvm.Benchmarks.mergesort, "mergeImp", "@main", 0)
   }
 }

--- a/dev-clean/src/main/scala/sai/llscImp/Driver.scala
+++ b/dev-clean/src/main/scala/sai/llscImp/Driver.scala
@@ -140,10 +140,10 @@ object RunLLSC {
 
     //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.branch, "branch", "@f", 2)
     //runLLSC(sai.llvm.Benchmarks.branch, "branchImp", "@f", 2)
-    sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.maze, "maze", "@main", 0)
-    runLLSC(sai.llvm.Benchmarks.maze, "mazeImp", "@main", 0)
-    // sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.power, "power", "@main", 0)
-    // runLLSC(sai.llvm.Benchmarks.power, "powerImp", "@main", 0)
+    //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.maze, "maze", "@main", 0)
+    //runLLSC(sai.llvm.Benchmarks.maze, "mazeImp", "@main", 0)
+    sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.power, "power", "@main", 0)
+    runLLSC(sai.llvm.Benchmarks.power, "powerImp", "@main", 0)
 
   }
 }

--- a/dev-clean/src/main/scala/sai/llscImp/Driver.scala
+++ b/dev-clean/src/main/scala/sai/llscImp/Driver.scala
@@ -123,7 +123,7 @@ object RunLLSC {
   }
 
   def main(args: Array[String]): Unit = {
-    /*
+    // /*
     val usage = """
     Usage: llsc <.ll-filepath> <app-name> <entrance-fun-name> [n-sym-var]
     """
@@ -136,12 +136,14 @@ object RunLLSC {
       val nSym = if (args.isDefinedAt(3)) args(3).toInt else 0
       runLLSC(parseFile(filepath), appName, fun, nSym)
     }
-     */
+    //  */
 
     //sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.branch, "branch", "@f", 2)
     //runLLSC(sai.llvm.Benchmarks.branch, "branchImp", "@f", 2)
     sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.maze, "maze", "@main", 0)
     runLLSC(sai.llvm.Benchmarks.maze, "mazeImp", "@main", 0)
+    // sai.llsc.RunLLSC.runLLSC(sai.llvm.Benchmarks.power, "power", "@main", 0)
+    // runLLSC(sai.llvm.Benchmarks.power, "powerImp", "@main", 0)
 
   }
 }

--- a/dev-clean/src/main/scala/sai/llscImp/SymExeState.scala
+++ b/dev-clean/src/main/scala/sai/llscImp/SymExeState.scala
@@ -142,6 +142,8 @@ trait SymExeDefs extends SAIOps with StagedNondet {
     override def lookup(x: String): Rep[Value] = lookupOpt(x.hashCode, Unwrap(ss), super.lookup(x), 5)
   }
 
+  implicit class RefSSOps(ss: Rep[Ref[SS]]) extends SSOpsOpt(ss.asRepOf[SS])
+
   def getRealBlockFunName(bf: Rep[Ref[SS] => List[(SS, Value)]]): String = {
     FunName.blockMap(Unwrap(bf).asInstanceOf[Backend.Sym].n)
   }

--- a/dev-clean/src/main/scala/sai/llscImp/SymExeState.scala
+++ b/dev-clean/src/main/scala/sai/llscImp/SymExeState.scala
@@ -142,7 +142,7 @@ trait SymExeDefs extends SAIOps with StagedNondet {
     override def lookup(x: String): Rep[Value] = lookupOpt(x.hashCode, Unwrap(ss), super.lookup(x), 5)
   }
 
-  def getRealBlockFunName(bf: Rep[SS => List[(SS, Value)]]): String = {
+  def getRealBlockFunName(bf: Rep[Ref[SS] => List[(SS, Value)]]): String = {
     FunName.blockMap(Unwrap(bf).asInstanceOf[Backend.Sym].n)
   }
 
@@ -172,7 +172,7 @@ trait SymExeDefs extends SAIOps with StagedNondet {
       Rep[Value] = "make_LocV".reflectMutableWith[Value](l, kind, size)
   }
   object FunV {
-    def apply(f: Rep[(SS, List[Value]) => List[(SS, Value)]]): Rep[Value] = f.asRepOf[Value]
+    def apply(f: Rep[(Ref[SS], List[Value]) => List[(SS, Value)]]): Rep[Value] = f.asRepOf[Value]
   }
   object SymV {
     def apply(s: Rep[String]): Rep[Value] = apply(s, DEFAULT_INT_BW)

--- a/dev-clean/src/main/scala/sai/llvm/Benchmarks.scala
+++ b/dev-clean/src/main/scala/sai/llvm/Benchmarks.scala
@@ -38,6 +38,10 @@ object Benchmarks {
   lazy val simple0 = parseFile("benchmarks/ccbse/simple_0.ll")
   lazy val simple1 = parseFile("benchmarks/ccbse/simple_1.ll")
   lazy val simple2 = parseFile("benchmarks/ccbse/simple_2.ll")
+
+  lazy val mergesort = parseFile("benchmarks/demo_benchmarks/mergesort.ll")
+  lazy val quicksort = parseFile("benchmarks/demo_benchmarks/quicksort.ll")
+  lazy val bubblesort = parseFile("benchmarks/demo_benchmarks/bubblesort.ll")
 }
 
 object LLSCExpr {

--- a/dev-clean/src/main/scala/sai/lms/CppBackend.scala
+++ b/dev-clean/src/main/scala/sai/lms/CppBackend.scala
@@ -16,6 +16,13 @@ trait CppSAICodeGenBase extends ExtendedCPPCodeGen
     with CppCodeGen_Set  with STPCodeGen_SMTBase with STPCodeGen_SMTBV
     with STPCodeGen_SMTArray {
 
+  override def remap(m: Manifest[_]): String = {
+    if (m.runtimeClass.getName.endsWith("$Ref")) {
+      val kty = m.typeArguments(0)
+      s"${remap(kty)}&"
+    } else super.remap(m)
+  }
+
   override def quote(s: Def): String = s match {
     case Const(()) => "std::monostate{}";
     case _ => super.quote(s)

--- a/dev-clean/src/main/scala/sai/lms/SAIOps.scala
+++ b/dev-clean/src/main/scala/sai/lms/SAIOps.scala
@@ -89,6 +89,10 @@ trait SAIOps extends Base
     }
   }
 
+  // Exclusively for C++
+
+  abstract class Ref[T: Manifest]
+
   // Experiment below -- do not use.
   // type CloseFun[A, B] = Rep[B] => Rep[A => B]
   // def close[A: Manifest, B: Manifest, M[_], C: Manifest, N[_], D: Manifest]


### PR DESCRIPTION
This will serve as the discussion continued from #23 

Basically, I'm assuming single usage of `SS`, i.e. within one function, there is only one active `SS` in use (correct me if it is not the case). Thus, here move semantics are primarily used to imitate ownership transferring, although C++ has no support for use-after-move checking. Such usage is solely for compatibility with analysis code generated from the current frontend, and I believe they can be migrated to in-place operators with `void` types smoothly. In fact, if the frontend starts to generate in-place code, I believe the backend will work instantly.

Have added fork cloning since, and now it can compile with `kmpmatcher` with no errors. I am still looking into segfaults.