### PR TITLE
Escape loop

### DIFF
--- a/dev-clean/benchmarks/external_lib/assert.c
+++ b/dev-clean/benchmarks/external_lib/assert.c
@@ -18,7 +18,9 @@ int main() {
   if (x == 2 && y == 3) {
     llsc_assert(x + y == 5); // symbolically valid, so will be ignored.
   }
-  flip(x); // llsc_assert should break, below will be skipped; only one test case will be generated.
+  // the llsc_assert in flip should break.
+  // however with random exploration, we cannot guarantee only one test case will be generated.
+  flip(x);
   if (x < 0) {
     flip(x);
   }

--- a/dev-clean/benchmarks/llvm/unboundedLoop.c
+++ b/dev-clean/benchmarks/llvm/unboundedLoop.c
@@ -1,0 +1,19 @@
+#include <stdbool.h>
+
+void llsc_assert(bool);
+void f() {
+  int i = 0;
+  while (i < 5) { i++; }
+}
+
+int main() {
+  int a;
+  make_symbolic(&a, 4);
+  int i = 0;
+  while (i < a) {
+    f();
+    i++;
+  }
+  // the engine should be able to reach this
+  llsc_assert(false);
+}

--- a/dev-clean/headers/llsc/auxiliary.hpp
+++ b/dev-clean/headers/llsc/auxiliary.hpp
@@ -12,13 +12,16 @@ inline unsigned int bitwidth = 32;
 inline unsigned int addr_bw = 64;
 inline unsigned int var_name = 0;
 
-// TODO: refactor those counters into Monitor
 inline std::atomic<unsigned int> num_async = 0;
 inline std::atomic<unsigned int> tt_num_async = 0;
 
 inline unsigned int test_query_num = 0;
 inline unsigned int br_query_num = 0;
 inline unsigned int cached_query_num = 0;
+
+// the maximal number of additional parallel thread (excluding main thread)
+inline unsigned int max_par_num = 0;
+inline unsigned int timeout = 0;
 
 inline duration<double, std::micro> solver_time = microseconds::zero();
 

--- a/dev-clean/headers/llsc/auxiliary.hpp
+++ b/dev-clean/headers/llsc/auxiliary.hpp
@@ -19,8 +19,8 @@ inline unsigned int test_query_num = 0;
 inline unsigned int br_query_num = 0;
 inline unsigned int cached_query_num = 0;
 
-// the maximal number of additional parallel thread (excluding main thread)
-inline unsigned int max_par_num = 0;
+// the maximal number of total threads (including the main thread)
+inline unsigned int n_thread = 1;
 inline unsigned int timeout = 3600; // in seconds, one hour by default
 
 inline duration<double, std::micro> solver_time = microseconds::zero();

--- a/dev-clean/headers/llsc/auxiliary.hpp
+++ b/dev-clean/headers/llsc/auxiliary.hpp
@@ -12,6 +12,8 @@ inline unsigned int bitwidth = 32;
 inline unsigned int addr_bw = 64;
 inline unsigned int var_name = 0;
 
+inline std::atomic<std::optional<int>> exit_code;
+
 inline std::atomic<unsigned int> num_async = 0;
 inline std::atomic<unsigned int> tt_num_async = 0;
 
@@ -37,6 +39,16 @@ enum iOP {
 enum fOP {
   op_fadd, op_fsub, op_fmul, op_fdiv
 };
+
+// Note: set_exit_code preserves the first value it sets.
+// In execution with thread_pool, this means other paths
+// invoking it later will be discarded and have no effect
+// on `main`'s return code.
+inline void set_exit_code(int code) {
+  if (!exit_code.load().has_value()) {
+    exit_code.store(std::make_optional<int>(code));
+  }
+}
 
 inline std::string int_op2string(iOP op) {
   switch (op) {

--- a/dev-clean/headers/llsc/auxiliary.hpp
+++ b/dev-clean/headers/llsc/auxiliary.hpp
@@ -21,7 +21,7 @@ inline unsigned int cached_query_num = 0;
 
 // the maximal number of additional parallel thread (excluding main thread)
 inline unsigned int max_par_num = 0;
-inline unsigned int timeout = 0;
+inline unsigned int timeout = 3600; // in seconds, one hour by default
 
 inline duration<double, std::micro> solver_time = microseconds::zero();
 

--- a/dev-clean/headers/llsc/branch.hpp
+++ b/dev-clean/headers/llsc/branch.hpp
@@ -48,21 +48,9 @@ sym_exec_br_k(SS ss, PtrVal t_cond, PtrVal f_cond,
     SS tbr_ss = ss.add_PC(t_cond);
     SS fbr_ss = ss.add_PC(f_cond);
 #if USE_TP
-    if (max_par_num > 0) {
-      tp.add_task([tf, tbr_ss, t_cond, k]{ tf(tbr_ss, k); });
-      //ff(fbr_ss, k);
-      tp.add_task([ff, fbr_ss, f_cond, k]{ ff(fbr_ss, k); });
-      return std::monostate{};
-    } else {
-      if (rand_int(100) > 50) {
-        tf(tbr_ss, k);
-        ff(fbr_ss, k);
-      } else {
-        ff(fbr_ss, k);
-        tf(tbr_ss, k);
-      }
-      return std::monostate{};
-    }
+    tp.add_task([tf, tbr_ss, t_cond, k]{ tf(tbr_ss, k); });
+    tp.add_task([ff, fbr_ss, f_cond, k]{ ff(fbr_ss, k); });
+    return std::monostate{};
 #else
     if (can_par_async()) {
       std::future<std::monostate> tf_res =

--- a/dev-clean/headers/llsc/branch.hpp
+++ b/dev-clean/headers/llsc/branch.hpp
@@ -1,6 +1,8 @@
 #ifndef LLSC_BRANCH_HEADERS
 #define LLSC_BRANCH_HEADERS
 
+// TODO: should be able to generate these functions too
+
 #ifdef PURE_STATE
 
 inline immer::flex_vector<std::pair<SS, PtrVal>>
@@ -48,12 +50,17 @@ sym_exec_br_k(SS ss, PtrVal t_cond, PtrVal f_cond,
 #if USE_TP
     if (max_par_num > 0) {
       tp.add_task([tf, tbr_ss, t_cond, k]{ tf(tbr_ss, k); });
-      ff(fbr_ss, k);
-      //tp.add_task([ff, fbr_ss, f_cond, k]{ ff(fbr_ss, k); });
+      //ff(fbr_ss, k);
+      tp.add_task([ff, fbr_ss, f_cond, k]{ ff(fbr_ss, k); });
       return std::monostate{};
     } else {
-      tf(tbr_ss, k);
-      ff(fbr_ss, k);
+      if (rand_int(100) > 50) {
+        tf(tbr_ss, k);
+        ff(fbr_ss, k);
+      } else {
+        ff(fbr_ss, k);
+        tf(tbr_ss, k);
+      }
       return std::monostate{};
     }
 #else

--- a/dev-clean/headers/llsc/cli.hpp
+++ b/dev-clean/headers/llsc/cli.hpp
@@ -33,8 +33,7 @@ inline void handle_cli_args(int argc, char** argv) {
     if (c == -1)
       break;
 
-    switch (c)
-    {
+    switch (c) {
       case 0:
         break;
       case 'd':

--- a/dev-clean/headers/llsc/cli.hpp
+++ b/dev-clean/headers/llsc/cli.hpp
@@ -80,11 +80,7 @@ inline void handle_cli_args(int argc, char** argv) {
         break;
       case 't': {
         int t = atoi(optarg);
-        if (t <= 1) {
-          max_par_num = 0;
-        } else {
-          max_par_num = t - 1;
-        }
+        n_thread = (t <= 0) ? 1 : t;
         break;
       }
       case 'e':
@@ -105,14 +101,14 @@ inline void handle_cli_args(int argc, char** argv) {
       exit(-1);
     }
   }
-  if (max_par_num == 0) {
+  if (n_thread == 1) {
     // It is safe the reuse the global_vc object within one thread, but not otherwise.
     std::cout << "Use global solver\n";
     use_global_solver = true;
-  } else {
-    std::cout << "Use " << (max_par_num+1) << " total threads\n";
-    tp.init(max_par_num);
   }
+  std::cout << "Use " << n_thread << " total threads\n";
+  // thread pool will create (n_thread) threads, leaving the main thread idle.
+  tp.init(n_thread);
   use_objcache = use_objcache && use_global_solver;
   use_cexcache = use_cexcache && use_global_solver;
 #ifdef DEBUG

--- a/dev-clean/headers/llsc/cli.hpp
+++ b/dev-clean/headers/llsc/cli.hpp
@@ -19,6 +19,7 @@ static struct option long_options[] =
   {"add-sym-file",         required_argument, 0, '+'},
   {"sym-file-size",        required_argument, 0, 's'},
   {"thread",               required_argument, 0, 't'},
+  {"timeout",              required_argument, 0, 'e'},
   {0,                      0,                 0, 0  }
 };
 
@@ -72,13 +73,13 @@ inline void handle_cli_args(int argc, char** argv) {
 #endif
         break;
       case 's':
-        default_sym_file_size = std::atoi(optarg);
+        default_sym_file_size = atoi(optarg);
 #ifdef DEBUG
         printf("set symfile size to %d\n", default_sym_file_size);
 #endif
         break;
       case 't': {
-        int t = std::stoi(optarg);
+        int t = atoi(optarg);
         if (t <= 1) {
           max_par_num = 0;
         } else {
@@ -86,6 +87,9 @@ inline void handle_cli_args(int argc, char** argv) {
         }
         break;
       }
+      case 'e':
+        timeout = atoi(optarg);
+        break;
       case '?':
         // parsing error, should be printed by getopt
       default:

--- a/dev-clean/headers/llsc/cli.hpp
+++ b/dev-clean/headers/llsc/cli.hpp
@@ -107,8 +107,10 @@ inline void handle_cli_args(int argc, char** argv) {
     use_global_solver = true;
   }
   std::cout << "Use " << n_thread << " total threads\n";
+#ifdef USE_TP
   // thread pool will create (n_thread) threads, leaving the main thread idle.
   tp.init(n_thread);
+#endif
   use_objcache = use_objcache && use_global_solver;
   use_cexcache = use_cexcache && use_global_solver;
 #ifdef DEBUG

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -119,8 +119,10 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> sym_exit(SS state, immer::flex_
 
 /* TODO: Generate both versions of sym_exit <2022-01-24, David Deng> */
 inline std::monostate sym_exit(SS state, immer::flex_vector<PtrVal> args, Cont k) {
+  ASSERT(args.size() == 1, "sym_exit accepts exactly one argument");
   auto v = args.at(0)->to_IntV();
-  auto status = v ? v->i : 0;
+  ASSERT(v != nullptr, "sym_exit only accepts integer argument");
+  int status = v->i;
   check_pc_to_file(state);
   epilogue();
   exit(status);

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -117,8 +117,13 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> sym_exit(SS state, immer::flex_
   ASSERT(v != nullptr, "sym_exit only accepts integer argument");
   int status = v->i;
   check_pc_to_file(state);
+#ifdef USE_TP
+  tp.stop_all_tasks();
+  return immer::flex_vector<std::pair<SS, PtrVal>>{};
+#else
   epilogue();
   exit(status);
+#endif
 }
 
 /* TODO: Generate both versions of sym_exit <2022-01-24, David Deng> */
@@ -128,8 +133,13 @@ inline std::monostate sym_exit(SS state, immer::flex_vector<PtrVal> args, Cont k
   ASSERT(v != nullptr, "sym_exit only accepts integer argument");
   int status = v->i;
   check_pc_to_file(state);
+#ifdef USE_TP
+  tp.stop_all_tasks();
+  return std::monostate{};
+#else
   epilogue();
   exit(status);
+#endif
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> llsc_assert(SS state, immer::flex_vector<PtrVal> args) {

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -119,6 +119,7 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> sym_exit(SS state, immer::flex_
   check_pc_to_file(state);
 #ifdef USE_TP
   tp.stop_all_tasks();
+  set_exit_code(status);
   return immer::flex_vector<std::pair<SS, PtrVal>>{};
 #else
   epilogue();
@@ -135,6 +136,7 @@ inline std::monostate sym_exit(SS state, immer::flex_vector<PtrVal> args, Cont k
   check_pc_to_file(state);
 #ifdef USE_TP
   tp.stop_all_tasks();
+  set_exit_code(status);
   return std::monostate{};
 #else
   epilogue();

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -58,10 +58,14 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> noop(SS state, immer::flex_vect
 }
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> stop(SS state, immer::flex_vector<PtrVal> args) {
+  check_pc_to_file(state);
   return immer::flex_vector<std::pair<SS, PtrVal>>{};
 }
 
-inline std::monostate stop(SS state, immer::flex_vector<PtrVal> args, Cont k) { return std::monostate(); }
+inline std::monostate stop(SS state, immer::flex_vector<PtrVal> args, Cont k) {
+  check_pc_to_file(state);
+  return std::monostate();
+}
 
 inline immer::flex_vector<std::pair<SS, PtrVal>> malloc(SS state, immer::flex_vector<PtrVal> args) {
   IntData bytes = proj_IntV(args.at(0));
@@ -132,14 +136,14 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llsc_assert(SS state, immer::fl
   auto v = args.at(0);
   auto i = v->to_IntV();
   if (i) {
-    if (i->i == 0) return stop(state, args); // concrete false - generate the test and exit FIXME: generate test case
+    if (i->i == 0) return stop(state, args); // concrete false - generate the test and exit
     return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(1, 32)}};
   }
   // otherwise add a symbolic condition that constraints it to be true
   // undefined/error if v is a value of other types
   auto cond = to_SMTNeg(v);
   auto new_s = state.add_PC(cond);
-  if (check_pc(new_s.get_PC())) return stop(state, args); // check if v == 1 is not valid FIXME: generate test case
+  if (check_pc(new_s.get_PC())) return stop(new_s, args); // check if v == 1 is not valid
   return immer::flex_vector<std::pair<SS, PtrVal>>{{state.add_PC(v), make_IntV(1, 32)}};
 }
 
@@ -147,14 +151,14 @@ inline std::monostate llsc_assert(SS state, immer::flex_vector<PtrVal> args, Con
   auto v = args.at(0);
   auto i = v->to_IntV();
   if (i) {
-    if (i->i == 0) return stop(state, args, k); // concrete false - generate the test and exit FIXME
+    if (i->i == 0) return stop(state, args, k); // concrete false - generate the test and exit
     return k(state, make_IntV(1, 32));
   }
   // otherwise add a symbolic condition that constraints it to be true
   // undefined/error if v is a value of other types
   auto cond = to_SMTNeg(v);
   auto new_s = state.add_PC(cond);
-  if (check_pc(new_s.get_PC())) return stop(state, args, k); // check if v == 1 is not valid FIXME
+  if (check_pc(new_s.get_PC())) return stop(new_s, args, k); // check if v == 1 is not valid
   return k(state.add_PC(v), make_IntV(1, 32));
 }
 

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -122,8 +122,8 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> sym_exit(SS state, immer::flex_
   set_exit_code(status);
   return immer::flex_vector<std::pair<SS, PtrVal>>{};
 #else
-  epilogue();
-  exit(status);
+  cov.print_all();
+  _exit(status);
 #endif
 }
 
@@ -135,12 +135,13 @@ inline std::monostate sym_exit(SS state, immer::flex_vector<PtrVal> args, Cont k
   int status = v->i;
   check_pc_to_file(state);
 #ifdef USE_TP
+  // XXX: brutally call _exit? then what should happen if two threads are calling sym_exit?
   tp.stop_all_tasks();
   set_exit_code(status);
   return std::monostate{};
 #else
-  epilogue();
-  exit(status);
+  cov.print_all();
+  _exit(status);
 #endif
 }
 

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -132,14 +132,14 @@ inline immer::flex_vector<std::pair<SS, PtrVal>> llsc_assert(SS state, immer::fl
   auto v = args.at(0);
   auto i = v->to_IntV();
   if (i) {
-    if (i->i == 0) sym_exit(state, args); // concrete false - generate the test and exit
+    if (i->i == 0) return stop(state, args); // concrete false - generate the test and exit FIXME: generate test case
     return immer::flex_vector<std::pair<SS, PtrVal>>{{state, make_IntV(1, 32)}};
   }
   // otherwise add a symbolic condition that constraints it to be true
   // undefined/error if v is a value of other types
   auto cond = to_SMTNeg(v);
   auto new_s = state.add_PC(cond);
-  if (check_pc(new_s.get_PC())) return stop(state, args); // check if v == 1 is not valid
+  if (check_pc(new_s.get_PC())) return stop(state, args); // check if v == 1 is not valid FIXME: generate test case
   return immer::flex_vector<std::pair<SS, PtrVal>>{{state.add_PC(v), make_IntV(1, 32)}};
 }
 
@@ -147,14 +147,14 @@ inline std::monostate llsc_assert(SS state, immer::flex_vector<PtrVal> args, Con
   auto v = args.at(0);
   auto i = v->to_IntV();
   if (i) {
-    if (i->i == 0) sym_exit(state, args); // concrete false - generate the test and exit
+    if (i->i == 0) return stop(state, args, k); // concrete false - generate the test and exit FIXME
     return k(state, make_IntV(1, 32));
   }
   // otherwise add a symbolic condition that constraints it to be true
   // undefined/error if v is a value of other types
   auto cond = to_SMTNeg(v);
   auto new_s = state.add_PC(cond);
-  if (check_pc(new_s.get_PC())) return stop(state, args, k); // check if v == 1 is not valid
+  if (check_pc(new_s.get_PC())) return stop(state, args, k); // check if v == 1 is not valid FIXME
   return k(state.add_PC(v), make_IntV(1, 32));
 }
 

--- a/dev-clean/headers/llsc/misc.hpp
+++ b/dev-clean/headers/llsc/misc.hpp
@@ -13,7 +13,9 @@ inline void epilogue() {
 #ifdef USE_TP
   tp.wait_for_tasks();
 #endif
+  std::cout << "wait for task\n" << std::flush;
   cov.stop_monitor();
+  std::cout << "stop mon\n" << std::flush;
   cov.print_time();
   cov.print_block_cov();
   cov.print_path_cov();

--- a/dev-clean/headers/llsc/misc.hpp
+++ b/dev-clean/headers/llsc/misc.hpp
@@ -15,11 +15,7 @@ inline void epilogue() {
   tp.wait_for_tasks();
 #endif
   cov.stop_monitor();
-  cov.print_time();
-  cov.print_block_cov();
-  cov.print_path_cov();
-  cov.print_async();
-  cov.print_query_stat();
+  cov.print_all();
 }
 
 #endif

--- a/dev-clean/headers/llsc/misc.hpp
+++ b/dev-clean/headers/llsc/misc.hpp
@@ -7,6 +7,7 @@ inline void prelude(int argc, char** argv) {
 #ifdef Z3
   cz3.init_solvers();
 #endif
+  cov.start_monitor();
 }
 
 inline void epilogue() {

--- a/dev-clean/headers/llsc/misc.hpp
+++ b/dev-clean/headers/llsc/misc.hpp
@@ -13,9 +13,7 @@ inline void epilogue() {
 #ifdef USE_TP
   tp.wait_for_tasks();
 #endif
-  std::cout << "wait for task\n" << std::flush;
   cov.stop_monitor();
-  std::cout << "stop mon\n" << std::flush;
   cov.print_time();
   cov.print_block_cov();
   cov.print_path_cov();

--- a/dev-clean/headers/llsc/monitor.hpp
+++ b/dev-clean/headers/llsc/monitor.hpp
@@ -56,8 +56,11 @@ struct Monitor {
       }
     }
     void print_async() {
-      // FIXME: thread pool version
+#ifdef USE_TP
+      std::cout << "#threads: " << n_thread << "; #task-in-q: " << tp.tasks_num_queued() << "; " << std::flush;
+#else
       std::cout << "#threads: " << num_async + 1 << "; #async created: " << tt_num_async << "; " << std::flush;
+#endif
     }
     void print_query_stat() {
       std::cout << "#queries: " << br_query_num << "/" << test_query_num << " (" << cached_query_num << ")\n" << std::flush;

--- a/dev-clean/headers/llsc/monitor.hpp
+++ b/dev-clean/headers/llsc/monitor.hpp
@@ -68,7 +68,7 @@ struct Monitor {
     }
     void start_monitor() {
       std::future<void> future = signal_exit.get_future();
-      watcher = std::thread([this](std::future<void> fut){
+      watcher = std::thread([this](std::future<void> fut) {
         while (this->block_cov.size() <= this->num_blocks &&
                fut.wait_for(milliseconds(1)) == std::future_status::timeout) {
           print_time();

--- a/dev-clean/headers/llsc/monitor.hpp
+++ b/dev-clean/headers/llsc/monitor.hpp
@@ -59,7 +59,7 @@ struct Monitor {
 #ifdef USE_TP
       std::cout << "#threads: " << n_thread << "; #task-in-q: " << tp.tasks_num_queued() << "; " << std::flush;
 #else
-      std::cout << "#threads: " << num_async + 1 << "; #async created: " << tt_num_async << "; " << std::flush;
+      std::cout << "#threads: " << num_async + 1 << "; #async-created: " << tt_num_async << "; " << std::flush;
 #endif
     }
     void print_query_stat() {

--- a/dev-clean/headers/llsc/parallel.hpp
+++ b/dev-clean/headers/llsc/parallel.hpp
@@ -11,7 +11,7 @@ inline thread_pool tp;
 inline std::mutex m;
 
 inline bool can_par_async() {
-  return num_async < max_par_num;
+  return num_async < n_thread;
 }
 
 template <typename F, typename... Ts>

--- a/dev-clean/headers/llsc/parallel.hpp
+++ b/dev-clean/headers/llsc/parallel.hpp
@@ -11,7 +11,7 @@ inline thread_pool tp;
 inline std::mutex m;
 
 inline bool can_par_async() {
-  return num_async < n_thread;
+  return num_async < n_thread-1;
 }
 
 template <typename F, typename... Ts>

--- a/dev-clean/headers/llsc/smt_stp.hpp
+++ b/dev-clean/headers/llsc/smt_stp.hpp
@@ -223,7 +223,7 @@ private:
 
 public:
   CheckerSTP() {
-    std::cout << "Using STP solver\n";
+    std::cout << "Use STP solver\n";
     vc = vc_createValidityChecker();
   }
   ~CheckerSTP() {

--- a/dev-clean/headers/llsc/smt_z3.hpp
+++ b/dev-clean/headers/llsc/smt_z3.hpp
@@ -18,7 +18,7 @@ private:
   solver* g_solver;
 public:
   CheckerZ3() {
-    std::cout << "Using Z3 solver\n";
+    std::cout << "Use Z3 solver\n";
   }
   ~CheckerZ3() { destroy_solvers(); }
   void init_solvers() override {

--- a/dev-clean/headers/llsc/thread_pool.hpp
+++ b/dev-clean/headers/llsc/thread_pool.hpp
@@ -16,9 +16,6 @@
 #include <type_traits>
 #include <utility>
 
-// the maximal number of additional parallel thread (excluding main thread)
-inline size_t max_par_num = 0;
-
 struct Task {
   std::function<void()> f;
   int weight;

--- a/dev-clean/headers/llsc/thread_pool.hpp
+++ b/dev-clean/headers/llsc/thread_pool.hpp
@@ -19,6 +19,18 @@
 // the maximal number of additional parallel thread (excluding main thread)
 inline size_t max_par_num = 0;
 
+struct Task {
+  std::function<void()> f;
+  int weight;
+};
+
+template<>
+struct std::less<Task> {
+  constexpr bool operator()(const Task& lhs, const Task& rhs) const {
+    return lhs.weight < rhs.weight;
+  }
+};
+
 class thread_pool {
 private:
   std::atomic<bool> running = true;
@@ -26,6 +38,7 @@ private:
 
   std::mutex q_lock = {};
   std::queue<std::function<void()>> tasks = {};
+  std::priority_queue<Task> ptasks = {};
 
   size_t thread_num;
   std::unique_ptr<std::thread[]> threads;
@@ -35,6 +48,7 @@ private:
   std::atomic<size_t> tasks_num_total = 0;
   bool inited = false;
 public:
+
   thread_pool(const size_t thread_num) :
     thread_num(thread_num), threads(new std::thread[thread_num]), thread_ids(new std::thread::id[thread_num]) {
     init(thread_num);
@@ -62,32 +76,44 @@ public:
     for (size_t i = 0; i < thread_num; i++) { f(thread_ids[i]); }
   }
   void add_task(const std::function<void()>& f) {
+    add_task(f, rand_int(1024));
+  }
+  void add_task(const std::function<void()>& f, int w) {
     tasks_num_total++;
     {
     const std::scoped_lock lock(q_lock);
-    tasks.push(f);
+    std::cout << "Adding task with weight " << w << "\n";
+    ptasks.push({f, w});
     }
   }
   void worker() {
+    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
     while (running) {
-      //std::cout << "worker running; running tasks " << running_tasks_num()
-      //          << "; queued tasks " << tasks_num_queued() << "\n";
-      std::function<void()> task;
+      // std::cout << "Running tasks " << running_tasks_num()
+      //           << "; queued tasks " << tasks_num_queued() << "\n";
+      struct Task task;
       if (!paused && pop_task(task)) {
         //std::cout << "thread " << std::this_thread::get_id() << " is running; " << running_tasks_num() << "\n";
-        task();
+        task.f();
         tasks_num_total--;
       } else {
         sleep_or_yield();
       }
     }
   }
-  bool pop_task(std::function<void()>& task) {
+  bool pop_task(struct Task& task) {
     const std::scoped_lock lock(q_lock);
-    if (tasks.empty()) return false;
-    task = std::move(tasks.front());
-    tasks.pop();
+    if (ptasks.empty()) return false;
+    task = std::move(ptasks.top());
+    ptasks.pop();
     return true;
+  }
+  void stop_all_tasks() {
+    for (size_t i = 0; i < thread_num; i++) {
+      std::cout << "cancel thread " << thread_ids[i] << "\n";
+      pthread_cancel(threads[i].native_handle());
+    }
+    tasks_num_total = 0;
   }
   void wait_for_tasks() {
     while (true) {
@@ -104,7 +130,7 @@ public:
   }
   size_t tasks_num_queued() {
     const std::scoped_lock lock(q_lock);
-    return tasks.size();
+    return ptasks.size();
   }
   void sleep_or_yield() {
     if (sleep_duration) std::this_thread::sleep_for(std::chrono::microseconds(sleep_duration));

--- a/dev-clean/headers/llsc/thread_pool.hpp
+++ b/dev-clean/headers/llsc/thread_pool.hpp
@@ -37,7 +37,6 @@ private:
   std::queue<std::function<void()>> tasks = {};
   std::priority_queue<Task> ptasks = {};
 
-  size_t thread_num;
   std::unique_ptr<std::thread[]> threads;
   std::unique_ptr<std::thread::id[]> thread_ids;
 
@@ -45,6 +44,7 @@ private:
   std::atomic<size_t> tasks_num_total = 0;
   bool inited = false;
 public:
+  size_t thread_num;
 
   thread_pool(const size_t thread_num) :
     thread_num(thread_num), threads(new std::thread[thread_num]), thread_ids(new std::thread::id[thread_num]) {

--- a/dev-clean/src/main/scala/sai/llsc/Codegen.scala
+++ b/dev-clean/src/main/scala/sai/llsc/Codegen.scala
@@ -185,7 +185,7 @@ trait GenericLLSCCodeGen extends CppSAICodeGenBase {
     |  $name(0);
     |#endif
     |  epilogue();
-    |  return 0;
+    |  return exit_code.load().value_or(0);
     |} """.stripMargin)
   }
 }

--- a/dev-clean/src/main/scala/sai/llsc/Codegen.scala
+++ b/dev-clean/src/main/scala/sai/llsc/Codegen.scala
@@ -179,7 +179,11 @@ trait GenericLLSCCodeGen extends CppSAICodeGenBase {
     emitln(s"""
     |int main(int argc, char *argv[]) {
     |  prelude(argc, argv);
+    |#ifdef USE_TP
+    |  tp.add_task([]() { $name(0); });
+    |#else
     |  $name(0);
+    |#endif
     |  epilogue();
     |  return 0;
     |} """.stripMargin)

--- a/dev-clean/src/main/scala/sai/llsc/Driver.scala
+++ b/dev-clean/src/main/scala/sai/llsc/Driver.scala
@@ -104,16 +104,16 @@ abstract class GenericLLSCDriver[A: Manifest, B: Manifest](appName: String, fold
   }
 
   // returns the number of paths, obtained by parsing the output
-  def run(nThread: Int = 1, opt: String = ""): Int = {
-    val cmd = s"./$appName $nThread $opt"
+  def run(opt: String = ""): Int = {
+    val cmd = s"./$appName $opt"
     System.out.println(s"running $cmd")
     val ret = Process(cmd, new File(s"$folder/$appName")).!!
     ret.split("\n").last.split(" ").last.toInt
   }
   // returns the number of paths, and the return status of the process
-  def runWithStatus(nThread: Int = 1, opt: String = ""): (String, Int) = {
+  def runWithStatus(opt: String = ""): (String, Int) = {
     import collection.mutable.ListBuffer
-    val cmd = s"./$appName $nThread $opt"
+    val cmd = s"./$appName $opt"
     System.out.println(s"running $cmd")
     val output = ListBuffer[String]()
     val ret = Process(cmd, new File(s"$folder/$appName")).run(ProcessLogger(r => output += r, e => output += e)).exitValue

--- a/dev-clean/src/main/scala/sai/llsc/Driver.scala
+++ b/dev-clean/src/main/scala/sai/llsc/Driver.scala
@@ -139,7 +139,6 @@ abstract class PureLLSCDriver[A: Manifest, B: Manifest](val m: Module, appName: 
 // avoding reifying the returned nondet list.
 abstract class PureCPSLLSCDriver[A: Manifest, B: Manifest](val m: Module, appName: String, folder: String = ".")
     extends GenericLLSCDriver[A, B](appName, folder) with PureCPSLLSCEngine { q =>
-  extraFlags = "-D USE_TP"
   val codegen = new PureLLSCCodeGen {
     val IR: q.type = q
     val codegenFolder = s"$folder/$appName/"

--- a/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
@@ -357,7 +357,6 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
     compile(funMap.map(_._2).toList)
     Coverage.setBlockNum
     Coverage.incPath(1)
-    Coverage.startMonitor
     val ss = initState(preHeap.asRepOf[Mem])
     if (!isCommandLine) {
       val fv = eval(GlobalId(fname), VoidType, ss)(fname)

--- a/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
@@ -474,7 +474,6 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
     }
     Coverage.setBlockNum
     Coverage.incPath(1)
-    Coverage.startMonitor
     reify[Value](initState(heap0))(comp)
   }
 }

--- a/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
@@ -356,7 +356,6 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
     compile(funMap.map(_._2).toList)
     Coverage.setBlockNum
     Coverage.incPath(1)
-    Coverage.startMonitor
     val ss = initState(preHeap.asRepOf[Mem])
     if (!isCommandLine) {
       val fv = eval(GlobalId(fname), VoidType, ss)(fname)

--- a/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
@@ -338,7 +338,6 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
     compile(funMap.map(_._2).toList)
     Coverage.setBlockNum
     Coverage.incPath(1)
-    Coverage.startMonitor
     val ss = initState(preHeap.asRepOf[Mem])
     if (!isCommandLine) {
       val fv = eval(GlobalId(fname), VoidType, ss)(fname)

--- a/dev-clean/src/main/scala/sai/prototypes/llvm/Benchmarks.scala
+++ b/dev-clean/src/main/scala/sai/prototypes/llvm/Benchmarks.scala
@@ -9,6 +9,7 @@ object Benchmarks {
   lazy val power = parseFile("benchmarks/llvm/power.ll")
   lazy val add = parseFile("benchmarks/llvm/add.ll")
   lazy val loop = parseFile("benchmarks/llvm/loopTest.ll")
+  lazy val unboundedLoop = parseFile("benchmarks/llvm/unboundedLoop.ll")
   lazy val branch = parseFile("benchmarks/llvm/branch.ll")
   lazy val branch2 = parseFile("benchmarks/llvm/branch2.ll")
   lazy val branch3 = parseFile("benchmarks/llvm/branch3.ll")

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -169,7 +169,7 @@ abstract class TestLLSC extends FunSuite {
       code.genAll
       val mkRet = code.make(2)
       assert(mkRet == 0, "make failed")
-      val (output, ret) = code.runWithStatus(1, cliArgOpt.getOrElse(""))
+      val (output, ret) = code.runWithStatus(cliArgOpt.getOrElse(""))
       System.err.println(output)
       val resStat = parseOutput(llsc.insName, name, output)
       System.err.println(resStat)

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -32,9 +32,13 @@ case class TestPrg(m: Module, name: String, f: String, nSym: Int, runOpt: Option
 object TestPrg {
   val nPath = "nPath"
   val nTest = "nTest"
+  val minPath = "minPath"
+  val minTest = "minTest"
   val status = "status"
   def nPath(n: Int): Map[String, Any] = Map(nPath -> n)
   def nTest(n: Int): Map[String, Any] = Map(nTest -> n)
+  def minTest(n: Int): Map[String, Any] = Map(minTest -> n)
+  def minPath(n: Int): Map[String, Any] = Map(minPath -> n)
   def status(n: Int): Map[String, Any] = Map(status -> n)
 
   implicit def lift[T](t: T): Option[T] = Some(t)
@@ -46,7 +50,6 @@ object TestCases {
     TestPrg(add, "addTest", "@main", 0, None, nPath(1)),
     TestPrg(power, "powerTest", "@main", 0, None, nPath(1)),
     TestPrg(global, "globalTest", "@main", 0, None, nPath(1)),
-    TestPrg(makeSymbolic, "makeSymbolicTest", "@main", 0, None, nPath(1)),
     TestPrg(ptrpred, "ptrPredTest", "@main", 0, None, nPath(1)),
     TestPrg(switchTestConc, "switchConcreteTest", "@main", 0, None, nPath(1)),
     TestPrg(trunc, "truncTest", "@main", 0, None, nPath(1)),
@@ -77,6 +80,7 @@ object TestCases {
   )
 
   val symbolicSimple: List[TestPrg] = List(
+    TestPrg(makeSymbolic, "makeSymbolicTest", "@main", 0, None, nPath(4)),
     TestPrg(branch, "branch1", "@f", 2, None, nPath(4)),
     TestPrg(branch2, "branch2", "@f", 2, None, nPath(4)),
     TestPrg(branch3, "branch3", "@f", 2, None, nPath(4)),
@@ -102,7 +106,7 @@ object TestCases {
   )
 
   val external: List[TestPrg] = List(
-    TestPrg(assertTest, "assertTest", "@main", 0, None, nPath(3)),
+    TestPrg(assertTest, "assertTest", "@main", 0, None, minPath(3)),
     TestPrg(assertfixTest, "assertfix", "@main", 0, None, nPath(4)),
   )
 
@@ -169,14 +173,20 @@ abstract class TestLLSC extends FunSuite {
       System.err.println(output)
       val resStat = parseOutput(llsc.insName, name, output)
       System.err.println(resStat)
-      if (exp.contains(nPath)) {
-        assert(resStat.pathNum == exp(nPath), "Unexpected path number")
-      }
       if (exp.contains(status)) {
         assert(ret == exp(status), "Unexpected returned status")
       }
+      if (exp.contains(nPath)) {
+        assert(resStat.pathNum == exp(nPath), "Unexpected path number")
+      }
+      if (exp.contains(minPath)) {
+        assert(resStat.pathNum >= exp(minPath).asInstanceOf[Int], "Unexpected number of least test cases")
+      }
       if (exp.contains(nTest)) {
         assert(resStat.testQueryNum == exp(nTest), "Unexpected number of test cases")
+      }
+      if (exp.contains(minTest)) {
+        assert(resStat.testQueryNum >= exp(minTest).asInstanceOf[Int], "Unexpected number of least test cases")
       }
     }
   }

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -213,7 +213,7 @@ class TestPureCPSLLSC_Z3 extends TestLLSC {
   //testLLSC(llsc, TestPrg(funptr, "funptr", "@main", 0, 1))
   //testLLSC(llsc, TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1))
   testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--timeout=2", minTest(1)))
-  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--thread=2 --timeout=2", minTest(1)))
+  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoopMT", "@main", 0, "--thread=2 --timeout=2", minTest(1)))
 }
 
 class TestImpLLSC extends TestLLSC {

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -209,7 +209,7 @@ class TestPureCPSLLSC extends TestLLSC {
 }
 
 class TestPureCPSLLSC_Z3 extends TestLLSC {
-  testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
+  //testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
   //testLLSC(llsc, TestPrg(funptr, "funptr", "@main", 0, 1))
   //testLLSC(llsc, TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1))
   testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, None, nTest(1)))

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -140,7 +140,7 @@ abstract class TestLLSC extends FunSuite {
 
   def parseOutput(engine: String, testName: String, output: String): TestResult = {
     // example:
-    // [43.4s/46.0s] #blocks: 12/12; #paths: 1666; #threads: 1; #async created: 0; #queries: 7328/1666 (1996)
+    // [43.4s/46.0s] #blocks: 12/12; #paths: 1666; #threads: 1; #task-in-q: 0; #queries: 7328/1666 (1996)
     val lastLine = output.split("\n").last
     val groups = lastLine.split(" ")
     val (solverTime, wholeTime) = {

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -68,7 +68,7 @@ object TestCases {
 
   val memModel: List[TestPrg] = List(
     TestPrg(funptr, "funptr", "@main", 0, None, nPath(1)),
-    TestPrg(heapFunptr, "heapFunptr", "@main", 0, None, nPath(1))
+    TestPrg(heapFunptr, "heapFunptr", "@main", 0, None, nPath(1)),
     TestPrg(ptrtoint, "ptrToInt", "@main", 0, None, nPath(1)),
     TestPrg(flexAddr, "flexAddr", "@main", 0, None, nPath(1)),
   )
@@ -180,7 +180,7 @@ abstract class TestLLSC extends FunSuite {
         assert(resStat.pathNum == exp(nPath), "Unexpected path number")
       }
       if (exp.contains(minPath)) {
-        assert(resStat.pathNum >= exp(minPath).asInstanceOf[Int], "Unexpected number of least test cases")
+        assert(resStat.pathNum >= exp(minPath).asInstanceOf[Int], "Unexpected number of least paths")
       }
       if (exp.contains(nTest)) {
         assert(resStat.testQueryNum == exp(nTest), "Unexpected number of test cases")

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -203,7 +203,7 @@ class TestPureLLSC extends TestLLSC {
 // FIXME: varArg is problematic for instances other than PureLLSC
 
 class TestPureCPSLLSC extends TestLLSC {
-  //testLLSC(new PureCPSLLSC, TestCases.all ++ filesys)
+  testLLSC(new PureCPSLLSC, TestCases.all ++ filesys)
   //testLLSC(new PureCPSLLSC, TestPrg(mergesort, "mergeSortTest", "@main", 0, 720))
   //testLLSC(new PureCPSLLSC, external)
 }

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -212,7 +212,7 @@ class TestPureCPSLLSC_Z3 extends TestLLSC {
   testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
   //testLLSC(llsc, TestPrg(funptr, "funptr", "@main", 0, 1))
   //testLLSC(llsc, TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1))
-  testLLSC(llsc, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, None, nTest(1)))
+  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, None, nTest(1)))
 }
 
 class TestImpLLSC extends TestLLSC {

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -209,10 +209,10 @@ class TestPureCPSLLSC extends TestLLSC {
 }
 
 class TestPureCPSLLSC_Z3 extends TestLLSC {
-  //testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
+  testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
   //testLLSC(llsc, TestPrg(funptr, "funptr", "@main", 0, 1))
   //testLLSC(llsc, TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1))
-  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, None, nTest(1)))
+  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--timeout=2", minTest(1)))
 }
 
 class TestImpLLSC extends TestLLSC {

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -212,7 +212,8 @@ class TestPureCPSLLSC_Z3 extends TestLLSC {
   testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
   //testLLSC(llsc, TestPrg(funptr, "funptr", "@main", 0, 1))
   //testLLSC(llsc, TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1))
-  //testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--timeout=2", minTest(1)))
+  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--timeout=2", minTest(1)))
+  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--thread=2 --timeout=2", minTest(1)))
 }
 
 class TestImpLLSC extends TestLLSC {

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -155,10 +155,10 @@ abstract class TestLLSC extends FunSuite {
     }
     val pathNum = groups(4).dropRight(1).toInt
     val (brQueryNum, testQueryNum) = {
-      val t = groups(11).split("/")
+      val t = groups(10).split("/")
       (t(0).toInt, t(1).toInt)
     }
-    val cexCacheHit = groups(12).drop(1).dropRight(1).toInt
+    val cexCacheHit = groups(11).drop(1).dropRight(1).toInt
     TestResult(engine, testName, solverTime, wholeTime, blockCov, pathNum, brQueryNum, testQueryNum, cexCacheHit)
   }
 
@@ -203,7 +203,7 @@ class TestPureLLSC extends TestLLSC {
 // FIXME: varArg is problematic for instances other than PureLLSC
 
 class TestPureCPSLLSC extends TestLLSC {
-  testLLSC(new PureCPSLLSC, TestCases.all ++ filesys)
+  //testLLSC(new PureCPSLLSC, TestCases.all ++ filesys)
   //testLLSC(new PureCPSLLSC, TestPrg(mergesort, "mergeSortTest", "@main", 0, 720))
   //testLLSC(new PureCPSLLSC, external)
 }
@@ -212,7 +212,7 @@ class TestPureCPSLLSC_Z3 extends TestLLSC {
   testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
   //testLLSC(llsc, TestPrg(funptr, "funptr", "@main", 0, 1))
   //testLLSC(llsc, TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1))
-  testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--timeout=2", minTest(1)))
+  //testLLSC(new PureCPSLLSC_Z3, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, "--timeout=2", minTest(1)))
 }
 
 class TestImpLLSC extends TestLLSC {

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -160,30 +160,24 @@ abstract class TestLLSC extends FunSuite {
 
   def testLLSC(llsc: LLSC, tst: TestPrg): Unit = {
     val TestPrg(m, name, f, nSym, cliArgOpt, exp) = tst
-    val expPathOpt = exp.get(nPath)
-    val expTestOpt = exp.get(nTest)
-    val expRetOpt = exp.get(status)
-    val cliArg = cliArgOpt.getOrElse("")
     test(name) {
       val code = llsc.newInstance(m, llsc.insName + "_" + name, f, nSym)
       code.genAll
       val mkRet = code.make(2)
       assert(mkRet == 0, "make failed")
-      val (output, ret) = code.runWithStatus(1, cliArg)
+      val (output, ret) = code.runWithStatus(1, cliArgOpt.getOrElse(""))
       System.err.println(output)
       val resStat = parseOutput(llsc.insName, name, output)
       System.err.println(resStat)
-      if (expPathOpt.nonEmpty) {
-        assert(resStat.pathNum == expPathOpt.get, "Unexpected path number")
+      if (exp.contains(nPath)) {
+        assert(resStat.pathNum == exp(nPath), "Unexpected path number")
       }
-      if (expRetOpt.nonEmpty) {
-        assert(ret == expRetOpt.get, "Unexpected returned status")
+      if (exp.contains(status)) {
+        assert(ret == exp(status), "Unexpected returned status")
       }
-      if (expTestOpt.nonEmpty) {
-        assert(resStat.testQueryNum == expTestOpt.get, "Unexpected number of test cases")
+      if (exp.contains(nTest)) {
+        assert(resStat.testQueryNum == exp(nTest), "Unexpected number of test cases")
       }
-      // TODO: check the number of generated test files?
-      // TODO: for concrete runs, also check result?
     }
   }
 

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -19,83 +19,102 @@ import sys.process._
 
 import org.scalatest.FunSuite
 
-case class TestPrg(m: Module, name: String, f: String, nSym: Int, nPath: Int,
-                   runOpt: String = "", result: Option[Int] = None)
+/* m: the parsed LLVM module
+ * name: test name
+ * f: entrance function name
+ * nSym: number of symbolic input to f
+ * nPath: expected number of explored paths
+ * nTest: expteted number of test cases generated
+ * runOpt: the command line argument to run the compiled executable
+ * result: expected return status of the compiled executable
+ */
+case class TestPrg(m: Module, name: String, f: String, nSym: Int, runOpt: Option[String], exp: Map[String, Any])
+object TestPrg {
+  val nPath = "nPath"
+  val nTest = "nTest"
+  val status = "status"
+  def nPath(n: Int): Map[String, Any] = Map(nPath -> n)
+  def nTest(n: Int): Map[String, Any] = Map(nTest -> n)
+  def status(n: Int): Map[String, Any] = Map(status -> n)
+
+  implicit def lift[T](t: T): Option[T] = Some(t)
+}
+import TestPrg._
 
 object TestCases {
   val concrete: List[TestPrg] = List(
-    TestPrg(add, "addTest", "@main", 0, 1),
-    TestPrg(power, "powerTest", "@main", 0, 1),
-    TestPrg(global, "globalTest", "@main", 0, 1),
-    TestPrg(makeSymbolic, "makeSymbolicTest", "@main", 0, 4),
-    TestPrg(ptrpred, "ptrPredTest", "@main", 0, 1),
-    TestPrg(switchTestConc, "switchConcreteTest", "@main", 0, 1),
-    TestPrg(trunc, "truncTest", "@main", 0, 1),
-    TestPrg(floatArith, "floatArithTest", "@main", 0, 1),
+    TestPrg(add, "addTest", "@main", 0, None, nPath(1)),
+    TestPrg(power, "powerTest", "@main", 0, None, nPath(1)),
+    TestPrg(global, "globalTest", "@main", 0, None, nPath(1)),
+    TestPrg(makeSymbolic, "makeSymbolicTest", "@main", 0, None, nPath(1)),
+    TestPrg(ptrpred, "ptrPredTest", "@main", 0, None, nPath(1)),
+    TestPrg(switchTestConc, "switchConcreteTest", "@main", 0, None, nPath(1)),
+    TestPrg(trunc, "truncTest", "@main", 0, None, nPath(1)),
+    TestPrg(floatArith, "floatArithTest", "@main", 0, None, nPath(1)),
     // FIXME: Support parsing fp80 literals <2022-01-12, David Deng> //
     // TestPrg(floatFp80, "floatFp80Test", "@main", 0, 1),
 
-    TestPrg(arrayAccess, "arrayAccTest", "@main", 0, 1),
-    TestPrg(arrayAccessLocal, "arrayAccLocalTest", "@main", 0, 1),
-    TestPrg(arrayGetSet, "arrayGetSetTest", "@main", 0, 1),
-    TestPrg(complexStruct, "complexStructTest", "@main", 0, 1),
-    TestPrg(structReturnLong, "structReturnLongTest", "@main", 0, 1),
-    TestPrg(structAccess, "structAccessTest", "@main", 0, 1),
-    TestPrg(structReturn, "structReturnTest", "@main", 0, 1),
+    TestPrg(arrayAccess, "arrayAccTest", "@main", 0, None, nPath(1)),
+    TestPrg(arrayAccessLocal, "arrayAccLocalTest", "@main", 0, None, nPath(1)),
+    TestPrg(arrayGetSet, "arrayGetSetTest", "@main", 0, None, nPath(1)),
+    TestPrg(complexStruct, "complexStructTest", "@main", 0, None, nPath(1)),
+    TestPrg(structReturnLong, "structReturnLongTest", "@main", 0, None, nPath(1)),
+    TestPrg(structAccess, "structAccessTest", "@main", 0, None, nPath(1)),
+    TestPrg(structReturn, "structReturnTest", "@main", 0, None, nPath(1)),
   )
-    
+
   val memModel: List[TestPrg] = List(
-    TestPrg(funptr, "funptr", "@main", 0, 1),
-    TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1),
-    TestPrg(ptrtoint, "ptrToInt", "@main", 0, 1),
-    TestPrg(flexAddr, "flexAddr", "@main", 0, 1),
+    TestPrg(funptr, "funptr", "@main", 0, None, nPath(1)),
+    TestPrg(heapFunptr, "heapFunptr", "@main", 0, None, nPath(1))
+    TestPrg(ptrtoint, "ptrToInt", "@main", 0, None, nPath(1)),
+    TestPrg(flexAddr, "flexAddr", "@main", 0, None, nPath(1)),
   )
 
   val varArg: List[TestPrg] = List(
-    TestPrg(varArgInt, "varArgInt", "@main", 0, 1),
+    TestPrg(varArgInt, "varArgInt", "@main", 0, None, nPath(1))
     // FIXME(PureLLSC): Sext an invalid value
-    // TestPrg(varArgChar, "varArgChar", "@main", 0, 1),
+    // TestPrg(varArgChar, "varArgChar", "@main", 0, None, nPath(1))
   )
 
   val symbolicSimple: List[TestPrg] = List(
-    TestPrg(branch, "branch1", "@f", 2, 4),
-    TestPrg(branch2, "branch2", "@f", 2, 4),
-    TestPrg(branch3, "branch3", "@f", 2, 4),
-    TestPrg(switchTestSym, "switchSymTest", "@main", 0, 5),
+    TestPrg(branch, "branch1", "@f", 2, None, nPath(4)),
+    TestPrg(branch2, "branch2", "@f", 2, None, nPath(4)),
+    TestPrg(branch3, "branch3", "@f", 2, None, nPath(4)),
+    TestPrg(switchTestSym, "switchSymTest", "@main", 0, None, nPath(5)),
   )
 
   val symbolicSmall: List[TestPrg] = List(
-    TestPrg(mergesort, "mergeSortTest", "@main", 0, 720),
-    TestPrg(bubblesort, "bubbleSortTest", "@main", 0, 24),
-    TestPrg(quicksort, "quickSortTest", "@main", 0, 120),
-    TestPrg(kmpmatcher, "kmp", "@main", 0, 1287),
-    TestPrg(kth, "k_of_st_arrays", "@main", 0, 252),
-    TestPrg(binSearch, "binSearch", "@main", 0, 92),
-    TestPrg(knapsack, "knapsackTest", "@main", 0, 1666),
+    TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)),
+    TestPrg(bubblesort, "bubbleSortTest", "@main", 0, None, nPath(24)),
+    TestPrg(quicksort, "quickSortTest", "@main", 0, None, nPath(120)),
+    TestPrg(kmpmatcher, "kmp", "@main", 0, None, nPath(1287)),
+    TestPrg(kth, "k_of_st_arrays", "@main", 0, None, nPath(252)),
+    TestPrg(binSearch, "binSearch", "@main", 0, None, nPath(92)),
+    TestPrg(knapsack, "knapsackTest", "@main", 0, None, nPath(1666)),
     // The oopsla20 version of maze
-    TestPrg(maze, "mazeTest", "@main", 2, 309),
-    TestPrg(mp1024, "mp1024Test", "@f", 10, 1024),
+    TestPrg(maze, "mazeTest", "@main", 2, None, nPath(309)),
+    TestPrg(mp1024, "mp1024Test", "@f", 10, None, nPath(1024)),
   )
 
   val symbolicLarge: List[TestPrg] = List(
-    TestPrg(mp65536, "mp65kTest", "@f", 16, 65536, "--disable-solver"),
-    TestPrg(mp1048576, "mp1mTest", "@f", 20, 1048576, "--disable-solver"),
+    TestPrg(mp65536, "mp65kTest", "@f", 16, "--disable-solver", nPath(65536)),
+    TestPrg(mp1048576, "mp1mTest", "@f", 20, "--disable-solver", nPath(1048576)),
   )
 
   val external: List[TestPrg] = List(
-    TestPrg(assertTest, "assertTest", "@main", 0, 3),
-    TestPrg(assertfixTest, "assertfix", "@main", 0, 4),
+    TestPrg(assertTest, "assertTest", "@main", 0, None, nPath(3)),
+    TestPrg(assertfixTest, "assertfix", "@main", 0, None, nPath(4)),
   )
 
   val filesys: List[TestPrg] = List(
-    TestPrg(openTest, "openTestSucc", "@main", 0, 1, "--add-sym-file A", Some(0)),
-    TestPrg(openTest, "openTestFail", "@main", 0, 1, "", Some(1)),
-    TestPrg(closeTest, "closeTest", "@main", 0, 1, "", Some(0)),
-    TestPrg(read1Test, "readTestRetVal", "@main", 0, 1, "--sym-file-size 10 --add-sym-file A", Some(0)),
-    TestPrg(read2Test, "readTestPaths", "@main", 0, 3, "--sym-file-size 3 --add-sym-file A", Some(0)),
-    TestPrg(write1Test, "writeTestPaths", "@main", 0, 2, "--sym-file-size 10 --add-sym-file A", Some(0)),
-    TestPrg(kleefsminiTest, "kleefsmini", "@main", 0, 2, "", Some(0)),
-    TestPrg(kleefsglobalTest, "kleefsminiglobal", "@main", 0, 2, "", Some(0)),
+    TestPrg(openTest, "openTestSucc", "@main", 0, "--add-sym-file A", nPath(1)++status(0)),
+    TestPrg(openTest, "openTestFail", "@main", 0, None, nPath(1)++status(1)),
+    TestPrg(closeTest, "closeTest", "@main", 0, None, nPath(1)++status(0)),
+    TestPrg(read1Test, "readTestRetVal", "@main", 0, "--sym-file-size 10 --add-sym-file A", nPath(1)++status(0)),
+    TestPrg(read2Test, "readTestPaths", "@main", 0, "--sym-file-size 3 --add-sym-file A", nPath(3)++status(0)),
+    TestPrg(write1Test, "writeTestPaths", "@main", 0, "--sym-file-size 10 --add-sym-file A", nPath(2)++status(0)),
+    TestPrg(kleefsminiTest, "kleefsmini", "@main", 0, None, nPath(2)++status(0)),
+    TestPrg(kleefsglobalTest, "kleefsminiglobal", "@main", 0, None, nPath(2)++status(0)),
   )
 
   val all: List[TestPrg] = concrete ++ memModel ++ symbolicSimple ++ symbolicSmall ++ external
@@ -140,20 +159,28 @@ abstract class TestLLSC extends FunSuite {
   }
 
   def testLLSC(llsc: LLSC, tst: TestPrg): Unit = {
-    val TestPrg(m, name, f, nSym, expPath, runOpt, expRetOpt) = tst
+    val TestPrg(m, name, f, nSym, cliArgOpt, exp) = tst
+    val expPathOpt = exp.get(nPath)
+    val expTestOpt = exp.get(nTest)
+    val expRetOpt = exp.get(status)
+    val cliArg = cliArgOpt.getOrElse("")
     test(name) {
       val code = llsc.newInstance(m, llsc.insName + "_" + name, f, nSym)
       code.genAll
       val mkRet = code.make(2)
       assert(mkRet == 0, "make failed")
-      val (output, ret) = code.runWithStatus(1, runOpt)
+      val (output, ret) = code.runWithStatus(1, cliArg)
       System.err.println(output)
       val resStat = parseOutput(llsc.insName, name, output)
       System.err.println(resStat)
-      val path = resStat.pathNum
-      assert(path == expPath, "Unexpected path number")
+      if (expPathOpt.nonEmpty) {
+        assert(resStat.pathNum == expPathOpt.get, "Unexpected path number")
+      }
       if (expRetOpt.nonEmpty) {
         assert(ret == expRetOpt.get, "Unexpected returned status")
+      }
+      if (expTestOpt.nonEmpty) {
+        assert(resStat.testQueryNum == expTestOpt.get, "Unexpected number of test cases")
       }
       // TODO: check the number of generated test files?
       // TODO: for concrete runs, also check result?
@@ -181,6 +208,7 @@ class TestPureCPSLLSC_Z3 extends TestLLSC {
   testLLSC(new PureCPSLLSC_Z3, TestCases.all ++ filesys)
   //testLLSC(llsc, TestPrg(funptr, "funptr", "@main", 0, 1))
   //testLLSC(llsc, TestPrg(heapFunptr, "heapFunptr", "@main", 0, 1))
+  testLLSC(llsc, TestPrg(unboundedLoop, "unboundedLoop", "@main", 0, None, nTest(1)))
 }
 
 class TestImpLLSC extends TestLLSC {


### PR DESCRIPTION
- Pure/CPS/Z3 
  + it can escape unbounded loop by using a priority queue in thread pool
  + the number of threads can be specified via `--thread=<n>`
  + it uses thread pool even for single-thread execution (i.e. looping over one worker thread)
  + sym_exit works gracefully for thread pool by "notifying" other worker threads to stop, but it has latency. 
    We could also just brutally call _exit, possibly leaving other threads in a random state.
- {Imp,Pure}/CPS/STP doesn't use thread pool because of an issue of STP
- async parallism seems to be fail on all other variants, perhaps due to some changes in the past since it is not tested in CI; I'm okay with that we don't maintain async anymore. So effectively all variants other than Pure/CPS/Z3 are single-thread sequential execution.
- all variants support timeout via `--timeout=<n>`
  + it is implemented by brutally call _exit, possibly leaving other threads in a random state.
  + Pure/CPS/Z3's thread pool could have a graceful exit too, but now the code is commented; seems not a big issue.
  + a graceful timeout for single-thread sequential execution requires more changes like adding checkpoints during execution, which I think has lower priority.
- Test cases now have a richer/extensible spec.
