### PR TITLE
Add alignment support for global variable initialization

### DIFF
--- a/dev-clean/benchmarks/external_lib/klee_fs_mini.c
+++ b/dev-clean/benchmarks/external_lib/klee_fs_mini.c
@@ -5,7 +5,16 @@ typedef struct {
 
 typedef struct {
   unsigned n_sym_files; /* number of symbolic input files, excluding stdin */
+  exe_disk_file_t *sym_stdin, *sym_stdout;
+  unsigned stdout_writes; /* how many chars were written to stdout */
   exe_disk_file_t *sym_files;
+  /* --- */
+  /* the maximum number of failures on one path; gets decremented after each failure */
+  unsigned max_failures;
+
+  /* Which read, write etc. call should fail */
+  int *read_fail, *write_fail, *close_fail, *ftruncate_fail, *getcwd_fail;
+  int *chmod_fail, *fchmod_fail;
 } exe_file_system_t;
 
 exe_file_system_t __exe_fs;

--- a/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
+++ b/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
@@ -201,13 +201,13 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
       case _ => LocV(evalAddr(v, ty), LocV.kHeap)
     }
     def evalConst(v: Constant, ty: LLVMType): List[Rep[Value]] = v match {
+      case CharArrayConst(s) => s.map(c => IntV(c.toInt, 8)).toList ++ StaticList.fill(getTySize(ty) - s.length)(NullV())
       case ZeroInitializerConst => IntV(0, 8 * getTySize(ty)) :: StaticList.fill(getTySize(ty) - 1)(NullV())
       case _ => evalValue(v, ty) :: StaticList.fill(getTySize(ty) - 1)(NullV())
     }
     def getcslist(v: Constant, ty: LLVMType): Option[StaticList[TypedConst]] = v match {
       case StructConst(cs) => Some(cs)
       case ArrayConst(cs) => Some(cs)
-      case CharArrayConst(s) => Some(s.map(c => TypedConst(Some(true), IntType(8), IntConst(c.toInt))).toList)
       case ZeroInitializerConst => ty match {
         case ArrayType(size, ety) => Some(StaticList.fill(size)(TypedConst(Some(true), ety, ZeroInitializerConst)))
         case Struct(types) => Some(types.map(ty => TypedConst(Some(true), ty, ZeroInitializerConst)))

--- a/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
+++ b/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
@@ -85,22 +85,22 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
   }
 
   object StructCalc {
-    private def padding(size: Int, align: Int): Int =
+    def padding(size: Int, align: Int): Int =
       size + (align - size % align) % align
-    
+
     private def offset(types: List[LLVMType]): (Int, Int) =
       types.foldLeft((0, 0)) { case ((size, align), ty) =>
         val (sz, al) = getTySizeAlign(ty)
         (padding(size, al) + sz, al max align)
       }
-    
+
     def getSizeAlign(types: List[LLVMType]): (Int, Int) = {
       val (size, align) = offset(types)
       (padding(size, align), align)
     }
 
     def getFieldOffset(types: List[LLVMType], idx: Int): Int =
-      offset(types.take(idx))._1
+      padding(offset(types.take(idx))._1, getTySizeAlign(types(idx))._2)
   }
 
   def getTySizeAlign(vt: LLVMType): (Int, Int) = vt match {
@@ -200,21 +200,30 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
       case BitCastExpr(from, const, to) => evalValue(const, to)
       case _ => LocV(evalAddr(v, ty), LocV.kHeap)
     }
-    val real_ty = getRealType(ty)
-    v match {
-      case StructConst(cs) =>
-        cs.flatMap { case c => evalHeapConst(c.const, c.ty) }
-      case ArrayConst(cs) =>
-        cs.flatMap { case c => evalHeapConst(c.const, c.ty) }
-      case CharArrayConst(s) =>
-        s.map(c => IntV(c.toInt, 8)).toList ++ StaticList.fill(getTySize(real_ty) - s.length)(NullV())
-      case ZeroInitializerConst => real_ty match {
-        case ArrayType(size, ety) => StaticList.fill(size)(evalHeapConst(ZeroInitializerConst, ety)).flatten
-        case Struct(types) => types.flatMap(evalHeapConst(ZeroInitializerConst, _))
-        // TODO: fallback case is not typed
-        case _ => IntV(0, 8 * getTySize(real_ty)) :: StaticList.fill(getTySize(real_ty) - 1)(NullV())
+    def evalConst(v: Constant, ty: LLVMType): List[Rep[Value]] = v match {
+      case ZeroInitializerConst => IntV(0, 8 * getTySize(ty)) :: StaticList.fill(getTySize(ty) - 1)(NullV())
+      case _ => evalValue(v, ty) :: StaticList.fill(getTySize(ty) - 1)(NullV())
+    }
+    def getcslist(v: Constant, ty: LLVMType): Option[StaticList[TypedConst]] = v match {
+      case StructConst(cs) => Some(cs)
+      case ArrayConst(cs) => Some(cs)
+      case CharArrayConst(s) => Some(s.map(c => TypedConst(Some(true), IntType(8), IntConst(c.toInt))).toList)
+      case ZeroInitializerConst => ty match {
+        case ArrayType(size, ety) => Some(StaticList.fill(size)(TypedConst(Some(true), ety, ZeroInitializerConst)))
+        case Struct(types) => Some(types.map(ty => TypedConst(Some(true), ty, ZeroInitializerConst)))
+        case _ => None
       }
-      case _ => evalValue(v, real_ty) :: StaticList.fill(getTySize(real_ty) - 1)(NullV())
+      case _ => None
+    }
+    val real_ty = getRealType(ty)
+    getcslist(v, real_ty) match {
+      case Some(cslist) =>
+        cslist.foldLeft (StaticList[Rep[Value]](), 0) { case ((l, align),c) =>
+          val (sz, al) = getTySizeAlign(c.ty)
+          val size = l.size
+          (l ++ StaticList.fill(StructCalc.padding(size, al) - size)(NullV()) ++ evalHeapConst(c.const, c.ty), al max align)
+        }._1
+      case None => evalConst(v, real_ty)
     }
   }
 


### PR DESCRIPTION
* fix global variable initialization: add alignment support for global variable initialization
* refactor: refactor the evalHeapConst function
* fix: fix getFieldOffset function
* change klee_fs_mini.c testcase to reflect the change (will trigger error without the global variable alignment support)