### PR TITLE
Further simplify mem

### DIFF
--- a/dev-clean/benchmarks/demo_benchmarks/mergesort.c
+++ b/dev-clean/benchmarks/demo_benchmarks/mergesort.c
@@ -12,17 +12,17 @@ void merge(int arr[], int l, int m, int r)
     int i, j, k;
     int n1 = m - l + 1;
     int n2 = r - m;
- 
+
     /* create temp arrays */
     int* L = malloc(n1 * sizeof(int));
     int* R = malloc(n2 * sizeof(int));
- 
+
     /* Copy data to temp arrays L[] and R[] */
     for (i = 0; i < n1; i++)
         L[i] = arr[l + i];
     for (j = 0; j < n2; j++)
         R[j] = arr[m + 1 + j];
- 
+
     /* Merge the temp arrays back into arr[l..r]*/
     i = 0; // Initial index of first subarray
     j = 0; // Initial index of second subarray
@@ -38,14 +38,14 @@ void merge(int arr[], int l, int m, int r)
         }
         k++;
     }
- 
+
     /* Copy the remaining elements of L[], if there are any */
     while (i < n1) {
         arr[k] = L[i];
         i++;
         k++;
     }
- 
+
     /* Copy the remaining elements of R[], if there
     are any */
     while (j < n2) {
@@ -56,7 +56,7 @@ void merge(int arr[], int l, int m, int r)
     free(L);
     free(R);
 }
- 
+
 /* l is for left index and r is right index of the
 sub-array of arr to be sorted */
 void mergeSort(int arr[], int l, int r)
@@ -65,22 +65,25 @@ void mergeSort(int arr[], int l, int r)
         // Same as (l+r)/2, but avoids overflow for
         // large l and h
         int m = l + (r - l) / 2;
- 
+
         // Sort first and second halves
         mergeSort(arr, l, m);
         mergeSort(arr, m + 1, r);
- 
+
         merge(arr, l, m, r);
     }
 }
- 
+
 int main()
 {
 #ifdef KLEE
   klee_make_symbolic(d, sizeof d, "data");
 #else
-	make_symbolic(d, sizeof(int) * SIZE);
+	//make_symbolic(d, sizeof(int) * SIZE);
+  for (int i = 0; i < SIZE; i++) {
+    make_symbolic_whole(d+i, sizeof(int)*8);
+  }
 #endif
-    mergeSort(d, 0, SIZE - 1);
-    return 0;
+  mergeSort(d, 0, SIZE - 1);
+  return 0;
 }

--- a/dev-clean/benchmarks/demo_benchmarks/mergesort.c
+++ b/dev-clean/benchmarks/demo_benchmarks/mergesort.c
@@ -81,7 +81,7 @@ int main()
 #else
 	//make_symbolic(d, sizeof(int) * SIZE);
   for (int i = 0; i < SIZE; i++) {
-    make_symbolic_whole(d+i, sizeof(int)*8);
+    make_symbolic_whole(d+i, sizeof(int));
   }
 #endif
   mergeSort(d, 0, SIZE - 1);

--- a/dev-clean/benchmarks/oopsla20/maze_test.c
+++ b/dev-clean/benchmarks/oopsla20/maze_test.c
@@ -45,7 +45,8 @@ void draw ()
 /**
  * The main function
  */
-int main (int argc, char *argv[])
+//int main (int argc, char *argv[])
+int main()
 {
   int x, y;     //Player position
   int ox, oy;   //Old player position
@@ -53,7 +54,7 @@ int main (int argc, char *argv[])
   #define ITERS 28
   char program[ITERS];
 
-  
+
   //Initial position
   x = 1;
   y = 1;
@@ -67,7 +68,7 @@ int main (int argc, char *argv[])
   // printf ("Try to reach the price(#)!\n");
 
   //Draw the maze
-  draw ();    
+  draw ();
   //Read the directions 'program' to execute...
   make_symbolic(program, ITERS);
 
@@ -98,7 +99,7 @@ int main (int argc, char *argv[])
         exit(-1);
     }
 
-    //If hit the price, You Win!!   
+    //If hit the price, You Win!!
     if (maze[y][x] == '#')
     {
       // printf ("You win!\n");
@@ -132,7 +133,7 @@ int main (int argc, char *argv[])
     //me wait to human
     // sleep(1);
   }
-  //You couldn't make it! You loose!	  
+  //You couldn't make it! You loose!
   // printf("You loose\n");
   exit(-2);
 }

--- a/dev-clean/headers/llsc/auxiliary.hpp
+++ b/dev-clean/headers/llsc/auxiliary.hpp
@@ -131,4 +131,7 @@ inline std::monostate operator+ (const std::monostate& lhs, const std::monostate
   return std::monostate{};
 }
 
+inline std::string fresh(const std::string& x) { return x + std::to_string(var_name++); }
+inline std::string fresh() { return fresh("x"); }
+
 #endif

--- a/dev-clean/headers/llsc/cli.hpp
+++ b/dev-clean/headers/llsc/cli.hpp
@@ -8,6 +8,8 @@ inline bool use_cexcache = true;
 inline bool use_cons_indep = false;
 inline bool exlib_failure_branch = false;
 
+// TODO: "--stack-size" to set stack size using `inc_stack`.
+
 static struct option long_options[] =
 {
   /* These options set a flag. */

--- a/dev-clean/headers/llsc/external_imp.hpp
+++ b/dev-clean/headers/llsc/external_imp.hpp
@@ -52,7 +52,7 @@ inline T __make_symbolic_whole(SS& state, List<PtrVal>& args, __Cont<T> k) {
   PtrVal loc = args.at(0);
   ASSERT(std::dynamic_pointer_cast<LocV>(loc) != nullptr, "Non-location value");
   IntData sz = proj_IntV(args.at(1));
-  state.update(loc, make_SymV(fresh(), sz));
+  state.update(loc, make_SymV(fresh(), sz*8));
   return k(state, make_IntV(0));
 }
 

--- a/dev-clean/headers/llsc/external_imp.hpp
+++ b/dev-clean/headers/llsc/external_imp.hpp
@@ -34,7 +34,7 @@ inline T __make_symbolic(SS& state, List<PtrVal>& args, __Cont<T> k) {
   IntData len = proj_IntV(args.at(1));
   //std::cout << "sym array size: " << proj_LocV_size(loc) << "\n";
   for (int i = 0; i < len; i++) {
-    state.update(loc + i, make_SymV("x" + std::to_string(var_name++), 8));
+    state.update(loc + i, make_SymV(fresh(), 8));
   }
   return k(state, make_IntV(0));
 }
@@ -46,6 +46,24 @@ inline List<SSVal> make_symbolic(SS& state, List<PtrVal> args) {
 inline std::monostate make_symbolic(SS& state, List<PtrVal> args, Cont k) {
   return __make_symbolic<std::monostate>(state, args, [&k](auto s, auto v) { return k(s, v); });
 }
+
+template<typename T>
+inline T __make_symbolic_whole(SS& state, List<PtrVal>& args, __Cont<T> k) {
+  PtrVal loc = args.at(0);
+  ASSERT(std::dynamic_pointer_cast<LocV>(loc) != nullptr, "Non-location value");
+  IntData sz = proj_IntV(args.at(1));
+  state.update(loc, make_SymV(fresh(), sz));
+  return k(state, make_IntV(0));
+}
+
+inline List<SSVal> make_symbolic_whole(SS& state, List<PtrVal> args) {
+  return __make_symbolic_whole<List<SSVal>>(state, args, [](auto s, auto v) { return List<SSVal>{{s, v}}; });
+}
+
+inline std::monostate make_symbolic_whole(SS& state, List<PtrVal> args, Cont k) {
+  return __make_symbolic_whole<std::monostate>(state, args, [&k](auto s, auto v) { return k(s, v); });
+}
+
 
 /******************************************************************************/
 

--- a/dev-clean/headers/llsc/external_imp.hpp
+++ b/dev-clean/headers/llsc/external_imp.hpp
@@ -151,8 +151,9 @@ inline T __llvm_memset(SS& state, List<PtrVal>& args, __Cont<T> k) {
   PtrVal dest = args.at(0);
   IntData bytes_int = proj_IntV(args.at(2));
   ASSERT(std::dynamic_pointer_cast<LocV>(dest) != nullptr, "Non-location value");
+  auto v = make_IntV(0, 8);
   for (int i = 0; i < bytes_int; i++) {
-    state.update(dest + i, IntV0);
+    state.update(dest + i, v);
   }
   return k(state, IntV0);
 }

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -56,7 +56,7 @@ inline T __make_symbolic_whole(SS& state, List<PtrVal>& args, __Cont<T> k) {
   PtrVal loc = args.at(0);
   ASSERT(std::dynamic_pointer_cast<LocV>(loc) != nullptr, "Non-location value");
   IntData sz = proj_IntV(args.at(1));
-  SS res = state.update(loc, make_SymV(fresh(), sz));
+  SS res = state.update(loc, make_SymV(fresh(), sz*8));
   return k(res, make_IntV(0));
 }
 

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -38,7 +38,7 @@ inline T __make_symbolic(SS& state, List<PtrVal>& args, __Cont<T> k) {
   SS res = state;
   //std::cout << "sym array size: " << proj_LocV_size(loc) << "\n";
   for (int i = 0; i < len; i++) {
-    res = res.update(loc + i, make_SymV("x" + std::to_string(var_name++), 8));
+    res = res.update(loc + i, make_SymV(fresh(), 8));
   }
   return k(res, make_IntV(0));
 }
@@ -49,6 +49,23 @@ inline List<SSVal> make_symbolic(SS state, List<PtrVal> args) {
 
 inline std::monostate make_symbolic(SS state, List<PtrVal> args, Cont k) {
   return __make_symbolic<std::monostate>(state, args, [&k](auto s, auto v) { return k(s, v); });
+}
+
+template<typename T>
+inline T __make_symbolic_whole(SS& state, List<PtrVal>& args, __Cont<T> k) {
+  PtrVal loc = args.at(0);
+  ASSERT(std::dynamic_pointer_cast<LocV>(loc) != nullptr, "Non-location value");
+  IntData sz = proj_IntV(args.at(1));
+  SS res = state.update(loc, make_SymV(fresh(), sz));
+  return k(res, make_IntV(0));
+}
+
+inline List<SSVal> make_symbolic_whole(SS state, List<PtrVal> args) {
+  return __make_symbolic_whole<List<SSVal>>(state, args, [](auto s, auto v) { return List<SSVal>{{s, v}}; });
+}
+
+inline std::monostate make_symbolic_whole(SS state, List<PtrVal> args, Cont k) {
+  return __make_symbolic_whole<std::monostate>(state, args, [&k](auto s, auto v) { return k(s, v); });
 }
 
 /******************************************************************************/

--- a/dev-clean/headers/llsc/external_pure.hpp
+++ b/dev-clean/headers/llsc/external_pure.hpp
@@ -158,9 +158,10 @@ inline T __llvm_memset(SS& state, List<PtrVal>& args, __Cont<T> k) {
   PtrVal dest = args.at(0);
   IntData bytes_int = proj_IntV(args.at(2));
   ASSERT(std::dynamic_pointer_cast<LocV>(dest) != nullptr, "Non-location value");
+  auto v = make_IntV(0, 8);
   SS res = state;
   for (int i = 0; i < bytes_int; i++) {
-    res = res.update(dest + i, IntV0);
+    res = res.update(dest + i, v);
   }
   return k(res, IntV0);
 }

--- a/dev-clean/headers/llsc/misc.hpp
+++ b/dev-clean/headers/llsc/misc.hpp
@@ -2,6 +2,7 @@
 #define LLSC_END_HEADERS
 
 inline void prelude(int argc, char** argv) {
+  inc_stack(STACKSIZE_128MB);
   init_rand();
   handle_cli_args(argc, argv);
 #ifdef Z3

--- a/dev-clean/headers/llsc/state_imp.hpp
+++ b/dev-clean/headers/llsc/state_imp.hpp
@@ -81,7 +81,7 @@ class Mem: public PreMem<PtrVal, Mem> {
       while (sz < size && !mem.at(idx + sz)) sz++;
       return { cur, idx, sz };
     }
-    while (cur == make_ShadowV()) cur = mem.at(--idx);
+    while (std::dynamic_pointer_cast<ShadowV>(cur)) cur = mem.at(--idx);
     return { cur, idx, size_t(cur->get_bw() + 7) / 8 };
   }
 

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -141,11 +141,11 @@ public:
       auto src_idx = idx + sv->offset;
       auto src = mem.at(src_idx);
       auto src_bytes = src->to_bytes();
-      // TODO: We don't need to write the whole byte seq of src, since the right-hand side part of it will be overwritten anyway
-      for (size_t i = 0; i < src_bytes.size(); i++) { mem.set(src_idx+i, src_bytes.at(i)); }
+      // We don't need to write the whole byte seq of src, since the part of it will be overwritten anyway
+      for (size_t i = 0; i < abs(sv->offset); i++) { mem.set(src_idx+i, src_bytes.at(i)); }
+      for (size_t i = abs(sv->offset)+byte_size; i < src_bytes.size(); i++) { mem.set(src_idx+i, src_bytes.at(i)); }
     }
     auto bytes = val->to_bytes_shadow();
-    ASSERT(bytes.size() == byte_size, "Size of byte-representation of value not equal to argument byte_size");
     for (size_t i = 0; i < byte_size; i++) {
       auto w = mem.at(idx + i);
       if (w && byte_size-i < w->get_byte_size()) {

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -272,6 +272,7 @@ public:
 };
 
 using Mem = MemIdxShadow;
+//using Mem = MemShadow;
 
 class Frame: public Printable {
   public:

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -148,7 +148,7 @@ class Mem: public PreMem<PtrVal, Mem> {
       while (sz < size && !mem.at(idx + sz)) sz++;
       return { cur, idx, sz };
     }
-    while (cur == make_ShadowV()) cur = mem.at(--idx);
+    while (std::dynamic_pointer_cast<ShadowV>(cur)) cur = mem.at(--idx);
     return { cur, idx, size_t(cur->get_bw() + 7) / 8 };
   }
 

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -104,10 +104,10 @@ public:
     ASSERT(!std::dynamic_pointer_cast<ShadowV>(old_val), "Updating a shadowed value");
     ASSERT(val->get_bw() == 1 || val->get_bw() == byte_size * 8, "Mismatched value and size to write");
     size_t end = idx + byte_size - 1;
-    auto raw_vals = val->unfold();
-    ASSERT(raw_vals.size() == byte_size, "Value raw representation not equal to byte_size");
+    auto bytes = val->to_bytes();
+    ASSERT(bytes.size() == byte_size, "Size of byte-representation of value not equal to argument byte_size");
     auto mem = this->mem.transient();
-    for (size_t i = 0; i < byte_size; i++) { mem.set(idx+i, raw_vals.at(i)); }
+    for (size_t i = 0; i < byte_size; i++) { mem.set(idx+i, bytes.at(i)); }
     return Mem0(mem.persistent());
   }
 };

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -83,9 +83,7 @@ private:
   }
 public:
   Mem0(List<PtrVal> mem) : PreMem(mem) {}
-  PtrVal at(size_t idx, size_t bit_size) {
-    ASSERT(bit_size == 1 || bit_size % 8 == 0, "Reading an invalid number of bits");
-    size_t byte_size = (bit_size == 1) ? 1 : bit_size / 8;
+  PtrVal at(size_t idx, size_t byte_size) {
     auto val = mem.at(idx);
     if (std::dynamic_pointer_cast<IntV>(val) || std::dynamic_pointer_cast<SymV>(val)) {
       auto span = slice(mem, idx, byte_size);
@@ -97,11 +95,10 @@ public:
     ASSERT(!std::dynamic_pointer_cast<ShadowV>(val), "Reading a shadowed value");
     return val;
   }
-  Mem0 update(size_t idx, PtrVal val, size_t bit_size) {
+  Mem0 update(size_t idx, PtrVal val, size_t byte_size) {
     auto old_val = mem.at(idx);
     ASSERT(!std::dynamic_pointer_cast<ShadowV>(old_val), "Updating a shadowed value");
-    size_t byte_size = (bit_size == 1) ? 1 : bit_size / 8;
-    ASSERT(val->get_bw() == bit_size, "Mismatched value and size to write");
+    ASSERT(val->get_bw() == 1 || val->get_bw() == byte_size * 8, "Mismatched value and size to write");
     size_t end = idx + byte_size - 1;
     auto raw_vals = val->unfold();
     ASSERT(raw_vals.size() == byte_size, "Value raw representation not equal to byte_size");

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -142,8 +142,8 @@ struct IntV : Value {
     if (bw <= 8) return List<PtrVal>{shared_from_this()};
     size_t byte_sz = bw / 8;
     auto res = List<PtrVal>{}.transient();
-    for (size_t i = byte_sz; i < 0; i--) {
-      res.push_back(bv_extract(shared_from_this(), i*8-1, (i-1)*8));
+    for (size_t i = 0; i < byte_sz; i++) {
+      res.push_back(bv_extract(shared_from_this(), (i+1)*8-1, i*8));
     }
     return res.persistent();
   }
@@ -331,8 +331,8 @@ struct SymV : Value {
     if (bw <= 8) return List<PtrVal>{shared_from_this()};
     size_t byte_sz = bw / 8;
     auto res = List<PtrVal>{}.transient();
-    for (size_t i = 0; i < byte_sz; i++) {
-      res.push_back(bv_extract(shared_from_this(), (i+1)*8-1, i*8));
+    for (size_t i = byte_sz; i > 0; i--) {
+      res.push_back(bv_extract(shared_from_this(), i*8-1, (i-1)*8));
     }
     return res.persistent();
   }

--- a/dev-clean/headers/llsc_client.h
+++ b/dev-clean/headers/llsc_client.h
@@ -1,0 +1,20 @@
+#ifndef LLSC_CLIENT_HEADERS
+#define LLSC_CLIENT_HEADERS
+
+#include <stddef.h>
+#include <stdbool.h>
+
+// TODO: support assigning names for symbolic values
+
+/* Construct `byte_size` 8-bitvectors starting at address `addr`.
+ */
+void make_symbolic(void* addr, size_t byte_size);
+
+/* Construct a single bitvector of size `byte_size`*8 at address `addr`.
+ */
+void make_symbolic_whole(void* addr, size_t byte_size);
+
+void llsc_assert(bool);
+void llsc_assert_eager(bool);
+
+#endif

--- a/dev-clean/headers/sai.hpp
+++ b/dev-clean/headers/sai.hpp
@@ -239,7 +239,7 @@ namespace Vec {
   template<typename T, typename U, typename Fn>
   inline U foldRight(immer::flex_vector<T> vec, U acc, Fn f) {
     static_assert(std::is_convertible<Fn, std::function<U(T, U)>>::value,
-      "Vec::foldLeft requires a function of type U(T, U)");
+      "Vec::foldRight requires a function of type U(T, U)");
     for (int i = vec.size()-1; i >= 0; i--) {
       acc = f(vec.at(i), acc);
     }

--- a/dev-clean/headers/sai.hpp
+++ b/dev-clean/headers/sai.hpp
@@ -290,6 +290,11 @@ namespace Vec {
       f(vec.at(i));
     }
   }
+
+  template<typename T>
+  inline immer::flex_vector<T> slice(immer::flex_vector<T> xs, size_t beg, size_t size) {
+    return xs.drop(beg).take(size);
+  }
 }
 
 namespace Tuple {

--- a/dev-clean/src/main/scala/sai/lang/LLVM.scala
+++ b/dev-clean/src/main/scala/sai/lang/LLVM.scala
@@ -184,7 +184,7 @@ package IR {
   case object FK_Double extends FloatKind
   case object FK_X86_FP80 extends FloatKind
   case object FK_FP128 extends FloatKind
-  case object FK_PPC_FP1289 extends FloatKind
+  case object FK_PPC_FP128 extends FloatKind
 
   abstract class LLVMType extends LAST
   case object VoidType extends LLVMType
@@ -603,7 +603,7 @@ class MyVisitor extends LLVMParserBaseVisitor[LAST] {
     else if (ctx.DOUBLE != null) FK_Double
     else if (ctx.X86_FP80 != null) FK_X86_FP80
     else if (ctx.FP128 != null) FK_FP128
-    else if (ctx.PPC_FP128 != null) FK_PPC_FP1289
+    else if (ctx.PPC_FP128 != null) FK_PPC_FP128
     else error
   }
 

--- a/dev-clean/src/main/scala/sai/llsc/Codegen.scala
+++ b/dev-clean/src/main/scala/sai/llsc/Codegen.scala
@@ -94,6 +94,9 @@ trait GenericLLSCCodeGen extends CppSAICodeGenBase {
     case Node(s, "ValPtr-deref", List(v), _) => es"*$v"
     case Node(s, "to-IntV", List(v), _) => es"$v->to_IntV()"
     case Node(s, "to-LocV", List(v), _) => es"make_LocV($v)"
+    case Node(s, "nullptr", _, _) => es"nullptr"
+    case Node(s, "to-bytes", List(v), _) => es"$v->to_bytes()"
+    case Node(s, "to-bytes-shadow", List(v), _) => es"$v->to_bytes_shadow()"
 
     case Node(s, "cov-set-blocknum", List(n), _) => es"cov.set_num_blocks($n)"
     case Node(s, "cov-inc-block", List(id), _) => es"cov.inc_block($id)"

--- a/dev-clean/src/main/scala/sai/llsc/Codegen.scala
+++ b/dev-clean/src/main/scala/sai/llsc/Codegen.scala
@@ -87,8 +87,6 @@ trait GenericLLSCCodeGen extends CppSAICodeGenBase {
     case Node(s, "ss-get-fs", List(ss), _) => es"$ss.get_fs()"
     case Node(s, "ss-set-fs", List(ss, fs), _) => es"$ss.set_fs($fs)"
     case Node(s, "get-pc", List(ss), _) => es"$ss.get_PC()"
-    case Node(s, "null-v", _, _) => es"nullptr"
-    case Node(s, "shadow-v", _, _) => es"make_ShadowV()"
 
     case Node(s, "is-conc", List(v), _) => es"$v->is_conc()"
     case Node(s, "to-SMT", List(v), _) => es"$v->to_SMT()"

--- a/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
+++ b/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
@@ -104,7 +104,7 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
       fields(types.take(idx+1))._1
     
     def concat[E](cs: List[E])(feval: E => (List[Rep[Value]], Int)): (List[Rep[Value]], Int) = {
-      val fill: Int => List[Rep[Value]] = (StaticList.fill(_)(NullV()))
+      val fill: Int => List[Rep[Value]] = (StaticList.fill(_)(NullPtr()))
       val (list, align) = cs.foldLeft((StaticList[Rep[Value]](), 0)) { case ((list, maxalign), c) =>
         val (value, align) = feval(c)
         (list ++ fill(padding(list.size, align)) ++ value, align max maxalign)
@@ -225,7 +225,7 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
           (l0 ++ va._1, va._2)
         }
       case CharArrayConst(s) =>
-        (s.map(c => IntV(c.toInt, 8)).toList ++ StaticList.fill(size - s.length)(NullV()), align)
+        (s.map(c => IntV(c.toInt, 8)).toList ++ StaticList.fill(size - s.length)(NullPtr()), align)
       case ZeroInitializerConst => real_ty match {
         case ArrayType(size, ety) =>
           val (value, align) = evalHeapConstWithAlign(ZeroInitializerConst, ety)
@@ -244,7 +244,7 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
 
   def precompileHeapLists(modules: StaticList[Module]): StaticList[Rep[Value]] = {
     var heapSize = 8
-    var heapTmp: StaticList[Rep[Value]] = StaticList.fill(heapSize)(NullV())
+    var heapTmp: StaticList[Rep[Value]] = StaticList.fill(heapSize)(NullPtr())
     for (module <- modules) {
       // module.funcDeclMap.foreach { case (k, v) =>
       //   heapEnv += k -> unit(heapSize)
@@ -257,7 +257,7 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
       //     heapSize += 8;
       //   }
       // }
-      // heapTmp ++= StaticList.fill(heapSize)(NullV())
+      // heapTmp ++= StaticList.fill(heapSize)(NullPtr())
       module.globalDeclMap.foreach { case (k, v) =>
         val realname = module.mname + "_" + v.id
         heapEnv += realname -> unit(heapSize);

--- a/dev-clean/src/main/scala/sai/llsc/External.scala
+++ b/dev-clean/src/main/scala/sai/llsc/External.scala
@@ -59,7 +59,7 @@ trait GenExternal extends SymExeDefs {
   }
 
   def close[T: Manifest](ss: Rep[SS], args: Rep[List[Value]], k: (Rep[SS], Rep[Value]) => Rep[T]): Rep[T] = {
-    val fd: Rep[Int] = args(0).to_IntV.int
+    val fd: Rep[Int] = args(0).toIntV.int
     val fs: Rep[FS] = ss.getFs
     val ret: Rep[Int] = fs.closeFile(fd)
     ss.setFs(fs)

--- a/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
@@ -53,7 +53,7 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
         else if (id.startsWith("@llvm")) Intrinsics.get(id)
         else {
           if (!External.warned.contains(id)) {
-            System.out.println(s"Warning: function $id is ignored")
+            System.out.println(s"Warning: function $id is treated as noop")
             External.warned.add(id)
           }
           External.noop

--- a/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
@@ -146,31 +146,30 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
 
       // Conversion Operations
       /* Backend Work Needed */
-      // TODO zext to type
-      case ZExtInst(from, value, to) =>
-        k(ss, eval(value, from, ss).bv_zext(to.asInstanceOf[IntType].size))
-      case SExtInst(from, value, to) =>
-        k(ss, eval(value, from, ss).bv_sext(to.asInstanceOf[IntType].size))
-      case TruncInst(from, value, to) =>
-        k(ss, eval(value, from, ss).trunc(from.asInstanceOf[IntType].size, to.asInstanceOf[IntType].size))
+      case ZExtInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).zExt(size))
+      case SExtInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).sExt(size))
+      case TruncInst(from@IntType(fromSz), value, IntType(toSz)) =>
+        k(ss, eval(value, from, ss).trunc(fromSz, toSz))
       case FpExtInst(from, value, to) =>
         // XXX: is it the right semantics?
         k(ss, eval(value, from, ss))
-      case FpToUIInst(from, value, to) =>
-        k(ss, eval(value, from, ss).fp_toui(to.asInstanceOf[IntType].size))
-      case FpToSIInst(from, value, to) =>
-        k(ss, eval(value, from, ss).fp_tosi(to.asInstanceOf[IntType].size))
+      case FpToUIInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).fromFloatToUInt(size))
+      case FpToSIInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).fromFloatToSInt(size))
       case UiToFPInst(from, value, to) =>
-        k(ss, eval(value, from, ss).ui_tofp)
+        k(ss, eval(value, from, ss).fromUIntToFloat)
       case SiToFPInst(from, value, to) =>
-        k(ss, eval(value, from, ss).si_tofp)
+        k(ss, eval(value, from, ss).fromSIntToFloat)
       case PtrToIntInst(from, value, to) =>
         import sai.llsc.Constants._
-        val v = eval(value, from, ss).to_IntV
+        val v = eval(value, from, ss).toIntV
         val toSize = to.asInstanceOf[IntType].size
         k(ss, if (ARCH_WORD_SIZE == toSize) v else v.trunc(ARCH_WORD_SIZE, toSize))
       case IntToPtrInst(from, value, to) =>
-        k(ss, eval(value, from, ss).to_LocV)
+        k(ss, eval(value, from, ss).toLocV)
       case BitCastInst(from, value, to) => k(ss, eval(value, to, ss))
 
       // Aggregate Operations

--- a/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
@@ -62,7 +62,7 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
         LocV(heapEnv(id), LocV.kHeap)
       case GlobalId(id) if globalDeclMap.contains(id) =>
         System.out.println(s"Warning: globalDecl $id is ignored")
-        NullV()
+        NullPtr()
       case GetElemPtrExpr(_, baseType, ptrType, const, typedConsts) =>
         // typedConst are not all int, could be local id
         val indexLLVMValue = typedConsts.map(tv => tv.const)
@@ -76,9 +76,9 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        NullV()
+        NullPtr()
       case NullConst => LocV.nullloc
-      case NoneConst => NullV()
+      case NoneConst => NullPtr()
     }
 
   def evalIntOp2(op: String, lhs: LLVMValue, rhs: LLVMValue, ty: LLVMType, ss: Rep[SS])(implicit funName: String): Rep[Value] =
@@ -240,7 +240,7 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
       case RetTerm(ty, v) =>
         val ret = v match {
           case Some(value) => eval(value, ty, ss)
-          case None => NullV()
+          case None => NullPtr()
         }
         k(ss, ret)
       case BrTerm(lab) =>

--- a/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
@@ -76,7 +76,7 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        NullPtr()
+        NullPtr() // FIXME: use uninitValue
       case NullConst => LocV.nullloc
       case NoneConst => NullPtr()
     }

--- a/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
@@ -66,7 +66,7 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
           else if (id.startsWith("@llvm")) Intrinsics.get(id)
           else {
             if (!External.warned.contains(id)) {
-              System.out.println(s"Warning: function $id is ignored")
+              System.out.println(s"Warning: function $id is treated as noop")
               External.warned.add(id)
             }
             External.noop

--- a/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
@@ -173,35 +173,31 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
 
       // Conversion Operations
       /* Backend Work Needed */
-      case ZExtInst(from, value, to) =>
-        for {
-          v <- eval(value, from)
-        } yield v.bv_zext(to.asInstanceOf[IntType].size)
-      case SExtInst(from, value, to) =>
-        for {
-          v <- eval(value, from)
-        } yield v.bv_sext(to.asInstanceOf[IntType].size)
-      case TruncInst(from, value, to) =>
-        for { v <- eval(value, from) } yield v.trunc(from.asInstanceOf[IntType].size, to.asInstanceOf[IntType].size)
+      case ZExtInst(from, value, IntType(size)) =>
+        for { v <- eval(value, from) } yield v.zExt(size)
+      case SExtInst(from, value, IntType(size)) =>
+        for { v <- eval(value, from) } yield v.sExt(size)
+      case TruncInst(from@IntType(fromSz), value, IntType(toSz)) =>
+        for { v <- eval(value, from) } yield v.trunc(fromSz, toSz)
       case FpExtInst(from, value, to) =>
         for { v <- eval(value, from) } yield v
-      case FpToUIInst(from, value, to) =>
-        for { v <- eval(value, from) } yield v.fp_toui(to.asInstanceOf[IntType].size)
-      case FpToSIInst(from, value, to) =>
-        for { v <- eval(value, from) } yield v.fp_tosi(to.asInstanceOf[IntType].size)
+      case FpToUIInst(from, value, IntType(size)) =>
+        for { v <- eval(value, from) } yield v.fromFloatToUInt(size)
+      case FpToSIInst(from, value, IntType(size)) =>
+        for { v <- eval(value, from) } yield v.fromFloatToSInt(size)
       case UiToFPInst(from, value, to) =>
-        for { v <- eval(value, from) } yield v.ui_tofp
+        for { v <- eval(value, from) } yield v.fromUIntToFloat
       case SiToFPInst(from, value, to) =>
-        for { v <- eval(value, from) } yield v.si_tofp
+        for { v <- eval(value, from) } yield v.fromSIntToFloat
       case PtrToIntInst(from, value, to) =>
         import Constants._
         for { v <- eval(value, from) } yield
           if (ARCH_WORD_SIZE == to.asInstanceOf[IntType].size) 
-            v.to_IntV
+            v.toIntV
           else
-            v.to_IntV.trunc(ARCH_WORD_SIZE, to.asInstanceOf[IntType].size)
+            v.toIntV.trunc(ARCH_WORD_SIZE, to.asInstanceOf[IntType].size)
       case IntToPtrInst(from, value, to) =>
-        for { v <- eval(value, from) } yield v.to_LocV
+        for { v <- eval(value, from) } yield v.toLocV
       case BitCastInst(from, value, to) => eval(value, to)
 
       // Aggregate Operations

--- a/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
@@ -93,7 +93,7 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        ret(NullPtr())
+        ret(NullPtr()) // FIXME: use uninitValue
       case NullConst => ret(LocV.nullloc)
       case NoneConst => ret(NullPtr())
     }

--- a/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
@@ -76,7 +76,7 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
         ret(LocV(heapEnv(id), LocV.kHeap))
       case GlobalId(id) if globalDeclMap.contains(id) =>
         System.out.println(s"Warning: globalDecl $id is ignored")
-        ret(NullV())
+        ret(NullPtr())
       case GetElemPtrExpr(_, baseType, ptrType, const, typedConsts) =>
         // typedConst are not all int, could be local id
         val indexLLVMValue = typedConsts.map(tv => tv.const)
@@ -93,9 +93,9 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        ret(NullV())
+        ret(NullPtr())
       case NullConst => ret(LocV.nullloc)
-      case NoneConst => ret(NullV())
+      case NoneConst => ret(NullPtr())
     }
   }
 
@@ -291,7 +291,7 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
       case RetTerm(ty, v) =>
         v match {
           case Some(value) => eval(value, ty)
-          case None => ret(NullV())
+          case None => ret(NullPtr())
         }
       case BrTerm(lab) =>
         for {

--- a/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
@@ -62,7 +62,7 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
         LocV(heapEnv(id), LocV.kHeap)
       case GlobalId(id) if globalDeclMap.contains(id) =>
         System.out.println(s"Warning: globalDecl $id is ignored")
-        NullV()
+        NullPtr()
       case GetElemPtrExpr(_, baseType, ptrType, const, typedConsts) =>
         // typedConst are not all int, could be local id
         val indexLLVMValue = typedConsts.map(tv => tv.const)
@@ -76,9 +76,9 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        NullV()
+        NullPtr()
       case NullConst => LocV.nullloc
-      case NoneConst => NullV()
+      case NoneConst => NullPtr()
     }
 
   def evalIntOp2(op: String, lhs: LLVMValue, rhs: LLVMValue, ty: LLVMType, ss: Rep[SS])(implicit funName: String): Rep[Value] =
@@ -241,7 +241,7 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
       case RetTerm(ty, v) =>
         v match {
           case Some(value) => eval(value, ty, ss)
-          case None => NullV()
+          case None => NullPtr()
         }
       case BrTerm(lab) =>
         ss.addIncomingBlock(incomingBlock)

--- a/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
@@ -147,31 +147,29 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
 
       // Conversion Operations
       /* Backend Work Needed */
-      // TODO zext to type
-      case ZExtInst(from, value, to) =>
-        k(ss, eval(value, from, ss).bv_zext(to.asInstanceOf[IntType].size))
-      case SExtInst(from, value, to) =>
-        k(ss, eval(value, from, ss).bv_sext(to.asInstanceOf[IntType].size))
-      case TruncInst(from, value, to) =>
-        k(ss, eval(value, from, ss).trunc(from.asInstanceOf[IntType].size, to.asInstanceOf[IntType].size))
+      case ZExtInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).zExt(size))
+      case SExtInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).sExt(size))
+      case TruncInst(from@IntType(fromSz), value, IntType(toSz)) =>
+        k(ss, eval(value, from, ss).trunc(fromSz, toSz))
       case FpExtInst(from, value, to) =>
         // XXX: is it the right semantics?
         k(ss, eval(value, from, ss))
-      case FpToUIInst(from, value, to) =>
-        k(ss, eval(value, from, ss).fp_toui(to.asInstanceOf[IntType].size))
-      case FpToSIInst(from, value, to) =>
-        k(ss, eval(value, from, ss).fp_tosi(to.asInstanceOf[IntType].size))
+      case FpToUIInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).fromFloatToUInt(size))
+      case FpToSIInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).fromFloatToSInt(size))
       case UiToFPInst(from, value, to) =>
-        k(ss, eval(value, from, ss).ui_tofp)
+        k(ss, eval(value, from, ss).fromUIntToFloat)
       case SiToFPInst(from, value, to) =>
-        k(ss, eval(value, from, ss).si_tofp)
-      case PtrToIntInst(from, value, to) =>
+        k(ss, eval(value, from, ss).fromSIntToFloat)
+      case PtrToIntInst(from, value, IntType(toSize)) =>
         import sai.llsc.Constants._
-        val v = eval(value, from, ss).to_IntV
-        val toSize = to.asInstanceOf[IntType].size
+        val v = eval(value, from, ss).toIntV
         k(ss, if (ARCH_WORD_SIZE == toSize) v else v.trunc(ARCH_WORD_SIZE, toSize))
       case IntToPtrInst(from, value, to) =>
-        k(ss, eval(value, from, ss).to_LocV)
+        k(ss, eval(value, from, ss).toLocV)
       case BitCastInst(from, value, to) =>
         k(ss, eval(value, to, ss))
 

--- a/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
@@ -76,7 +76,7 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        NullPtr()
+        NullPtr() // FIXME: use uninitValue
       case NullConst => LocV.nullloc
       case NoneConst => NullPtr()
     }

--- a/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
@@ -53,7 +53,7 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
         else if (id.startsWith("@llvm")) Intrinsics.get(id)
         else {
           if (!External.warned.contains(id)) {
-            System.out.println(s"Warning: function $id is ignored")
+            System.out.println(s"Warning: function $id is treated as noop")
             External.warned.add(id)
           }
           External.noop

--- a/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
@@ -82,7 +82,7 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        NullPtr()
+        NullPtr() // FIXME: use uninitValue
       case NullConst => LocV.nullloc
       case NoneConst => NullPtr()
     }

--- a/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
@@ -151,31 +151,29 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
 
       // Conversion Operations
       /* Backend Work Needed */
-      // TODO zext to type
-      case ZExtInst(from, value, to) =>
-        k(ss, eval(value, from, ss).bv_zext(to.asInstanceOf[IntType].size))
-      case SExtInst(from, value, to) =>
-        k(ss, eval(value, from, ss).bv_sext(to.asInstanceOf[IntType].size))
-      case TruncInst(from, value, to) =>
-        k(ss, eval(value, from, ss).trunc(from.asInstanceOf[IntType].size, to.asInstanceOf[IntType].size))
+      case ZExtInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).zExt(size))
+      case SExtInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).sExt(size))
+      case TruncInst(from@IntType(fromSz), value, IntType(toSz)) =>
+        k(ss, eval(value, from, ss).trunc(fromSz, toSz))
       case FpExtInst(from, value, to) =>
         // XXX: is it the right semantics?
         k(ss, eval(value, from, ss))
-      case FpToUIInst(from, value, to) =>
-        k(ss, eval(value, from, ss).fp_toui(to.asInstanceOf[IntType].size))
-      case FpToSIInst(from, value, to) =>
-        k(ss, eval(value, from, ss).fp_tosi(to.asInstanceOf[IntType].size))
+      case FpToUIInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).fromFloatToUInt(size))
+      case FpToSIInst(from, value, IntType(size)) =>
+        k(ss, eval(value, from, ss).fromFloatToSInt(size))
       case UiToFPInst(from, value, to) =>
-        k(ss, eval(value, from, ss).ui_tofp)
+        k(ss, eval(value, from, ss).fromUIntToFloat)
       case SiToFPInst(from, value, to) =>
-        k(ss, eval(value, from, ss).si_tofp)
-      case PtrToIntInst(from, value, to) =>
+        k(ss, eval(value, from, ss).fromSIntToFloat)
+      case PtrToIntInst(from, value, IntType(toSize)) =>
         import Constants._
-        val v = eval(value, from, ss).to_IntV
-        val toSize = to.asInstanceOf[IntType].size
+        val v = eval(value, from, ss).toIntV
         k(ss, if (ARCH_WORD_SIZE == toSize) v else v.trunc(ARCH_WORD_SIZE, toSize))
       case IntToPtrInst(from, value, to) =>
-        k(ss, eval(value, from, ss).to_LocV)
+        k(ss, eval(value, from, ss).toLocV)
       case BitCastInst(from, value, to) =>
         k(ss, eval(value, to, ss))
 

--- a/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
@@ -59,7 +59,7 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
         else if (id.startsWith("@llvm")) Intrinsics.get(id)
         else {
           if (!External.warned.contains(id)) {
-            System.out.println(s"Warning: function $id is ignored")
+            System.out.println(s"Warning: function $id is treated as noop")
             External.warned.add(id)
           }
           External.noop

--- a/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
@@ -68,7 +68,7 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
         LocV(heapEnv(id), LocV.kHeap)
       case GlobalId(id) if globalDeclMap.contains(id) =>
         System.out.println(s"Warning: globalDecl $id is ignored")
-        NullV()
+        NullPtr()
       case GetElemPtrExpr(_, baseType, ptrType, const, typedConsts) =>
         // typedConst are not all int, could be local id
         val indexLLVMValue = typedConsts.map(tv => tv.const)
@@ -82,9 +82,9 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
         }
       case ZeroInitializerConst =>
         System.out.println("Warning: Evaluate zeroinitialize in body")
-        NullV()
+        NullPtr()
       case NullConst => LocV.nullloc
-      case NoneConst => NullV()
+      case NoneConst => NullPtr()
     }
 
   def evalIntOp2(op: String, lhs: LLVMValue, rhs: LLVMValue, ty: LLVMType, ss: Rep[SS])(implicit funName: String): Rep[Value] =
@@ -235,7 +235,7 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
       case RetTerm(ty, v) =>
         val ret = v match {
           case Some(value) => eval(value, ty, ss)
-          case None => NullV()
+          case None => NullPtr()
         }
         k(ss, ret)
       case BrTerm(lab) =>

--- a/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
@@ -77,7 +77,7 @@ trait Opaques { self: SAIOps with BasicDefs =>
     val warned = MutableSet[String]()
     // TODO: specify the signature of those functions (both in C and Scala)
     val modeled = MutableSet[String](
-      "sym_print", "print_string", "malloc", "realloc", "llsc_assert", "make_symbolic",
+      "sym_print", "print_string", "malloc", "realloc", "llsc_assert", "make_symbolic", "make_symbolic_whole",
       "open", "close", "read", "write", "stat", "sym_exit", "llsc_assert_eager",
       "__assert_fail"
     )

--- a/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
@@ -260,8 +260,8 @@ trait ValueDefs { self: SAIOps with BasicDefs with Opaques =>
     
     def deref: Rep[Any] = "ValPtr-deref".reflectWith[Any](v)
 
-    def bv_sext(bw: Rep[Int]): Rep[Value] =  "bv_sext".reflectWith[Value](v, bw)
-    def bv_zext(bw: Rep[Int]): Rep[Value] =  "bv_zext".reflectWith[Value](v, bw)
+    def sExt(bw: Rep[Int]): Rep[Value] =  "bv_sext".reflectWith[Value](v, bw)
+    def zExt(bw: Rep[Int]): Rep[Value] =  "bv_zext".reflectWith[Value](v, bw)
 
     def isConc: Rep[Boolean] = v match {
       case IntV(_, _) => unit(true)
@@ -271,14 +271,13 @@ trait ValueDefs { self: SAIOps with BasicDefs with Opaques =>
     def toSMTBoolNeg: Rep[SMTBool] = "to-SMTNeg".reflectWith[SMTBool](v)
 
     def notNull: Rep[Boolean] = "not-null".reflectWith[Boolean](v)
-
-    def fp_toui(to: Int): Rep[Value] = "fp_toui".reflectWith[Value](v, to)
-    def fp_tosi(to: Int): Rep[Value] = "fp_tosi".reflectWith[Value](v, to)
-    def ui_tofp: Rep[Value] = "ui_tofp".reflectWith[Value](v)
-    def si_tofp: Rep[Value] = "si_tofp".reflectWith[Value](v)
+    def fromFloatToUInt(toSize: Int): Rep[Value] = "fp_toui".reflectWith[Value](v, toSize)
+    def fromFloatToSInt(toSize: Int): Rep[Value] = "fp_tosi".reflectWith[Value](v, toSize)
+    def fromUIntToFloat: Rep[Value] = "ui_tofp".reflectWith[Value](v)
+    def fromSIntToFloat: Rep[Value] = "si_tofp".reflectWith[Value](v)
     def trunc(from: Rep[Int], to: Rep[Int]): Rep[Value] =
       "trunc".reflectWith[Value](v, from, to)
-    def to_IntV: Rep[Value] = "to-IntV".reflectWith[Value](v)
-    def to_LocV: Rep[Value] = "to-LocV".reflectWith[Value](v)
+    def toIntV: Rep[Value] = "to-IntV".reflectWith[Value](v)
+    def toLocV: Rep[Value] = "to-LocV".reflectWith[Value](v)
   }
 }

--- a/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
@@ -203,7 +203,7 @@ trait ValueDefs { self: SAIOps with BasicDefs with Opaques =>
       StaticList.fill(size)(s)
     }
     def indexSeq(size: Int): StaticList[Rep[Value]] = {
-      require(size > 0)
+      require(size >= 0)
       StaticRange(-size, 0).reverse.map(ShadowV(_)).toList
     }
   }
@@ -297,8 +297,8 @@ trait ValueDefs { self: SAIOps with BasicDefs with Opaques =>
     def toBytes: Rep[List[Value]] = ???
     def toShadowBytes: Rep[List[Value]] = v match {
       case ShadowV() => List[Value](v)
-      case IntV(n, bw) => List[Value](v::ShadowV.indexSeq((bw+BYTE_SIZE-1)/BYTE_SIZE):_*)
-      case FloatV(f, bw) => List[Value](v::ShadowV.indexSeq((bw+BYTE_SIZE-1)/BYTE_SIZE):_*)
+      case IntV(n, bw) => List[Value](v::ShadowV.indexSeq((bw+BYTE_SIZE-1)/BYTE_SIZE - 1):_*)
+      case FloatV(f, bw) => List[Value](v::ShadowV.indexSeq((bw+BYTE_SIZE-1)/BYTE_SIZE - 1):_*)
       case LocV(_, _, _) | FunV(_) | CPSFunV(_) =>
         List[Value](v::ShadowV.indexSeq(7):_*)
       case _ => "to-bytes".reflectWith[List[Value]](v)

--- a/dev-clean/src/main/scala/sai/lms/ListOps.scala
+++ b/dev-clean/src/main/scala/sai/lms/ListOps.scala
@@ -81,6 +81,12 @@ trait ListOps { b: Base =>
       val block = Adapter.g.reify(x => Unwrap(f(Wrap[A](x))))
       Wrap[List[Unit]](Adapter.g.reflect("list-foreach", Unwrap(xs), block))
     }
+
+    def toStatic: List[Rep[A]] = Unwrap(xs) match {
+      case Adapter.g.Def("list-new",  _::(ys: List[Backend.Exp])) =>
+        ys.map(Wrap[A](_))
+      case _ => throw new Exception("List is not static")
+    }
   }
 }
 

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -100,7 +100,7 @@ object TestCases {
     TestPrg(knapsack, "knapsackTest", "@main", 0, None, nPath(1666)),
     TestPrg(nqueen, "nQueens", "@main", 0, None, nPath(1363)),
     // The oopsla20 version of maze
-    TestPrg(maze, "mazeTest", "@main", 2, None, nPath(309)),
+    TestPrg(maze, "mazeTest", "@main", 0, None, nPath(309)),
     TestPrg(mp1024, "mp1024Test", "@f", 10, None, nPath(1024)),
   )
 
@@ -237,9 +237,4 @@ class TestImpCPSLLSC extends TestLLSC {
 
 class Playground extends TestLLSC {
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
-  testLLSC(new PureCPSLLSC, memModel)
-  //testLLSC(new PureCPSLLSC_Z3, TestPrg(aliasing, "aliasingTest", "@main", 0, None, nPath(1)))
-  //testLLSC(new PureCPSLLSC, TestPrg(nqueen, "nQueens", "@main", 0, None, nPath(1363)))
-  //testLLSC(new PureCPSLLSC_Z3, TestPrg(nqueen, "nQueensZ3", "@main", 0, None, nPath(1363)))
-  //testLLSC(new PureLLSC, TestPrg(openTest, "openTestSucc", "@main", 0, "--add-sym-file A", nPath(1)++status(0)))
 }

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -237,7 +237,7 @@ class TestImpCPSLLSC extends TestLLSC {
 
 class Playground extends TestLLSC {
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
-  //testLLSC(new PureCPSLLSC, memModel)
+  testLLSC(new PureCPSLLSC, memModel)
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(aliasing, "aliasingTest", "@main", 0, None, nPath(1)))
   //testLLSC(new PureCPSLLSC, TestPrg(nqueen, "nQueens", "@main", 0, None, nPath(1363)))
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(nqueen, "nQueensZ3", "@main", 0, None, nPath(1363)))

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -236,9 +236,9 @@ class TestImpCPSLLSC extends TestLLSC {
 }
 
 class Playground extends TestLLSC {
-  //testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
+  testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(aliasing, "aliasingTest", "@main", 0, None, nPath(1)))
   //testLLSC(new PureCPSLLSC, TestPrg(nqueen, "nQueens", "@main", 0, None, nPath(1363)))
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(nqueen, "nQueensZ3", "@main", 0, None, nPath(1363)))
-  testLLSC(new PureLLSC, TestPrg(openTest, "openTestSucc", "@main", 0, "--add-sym-file A", nPath(1)++status(0)))
+  //testLLSC(new PureLLSC, TestPrg(openTest, "openTestSucc", "@main", 0, "--add-sym-file A", nPath(1)++status(0)))
 }

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -236,6 +236,9 @@ class TestImpCPSLLSC extends TestLLSC {
 }
 
 class Playground extends TestLLSC {
-  testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
+  //testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(aliasing, "aliasingTest", "@main", 0, None, nPath(1)))
+  //testLLSC(new PureCPSLLSC, TestPrg(nqueen, "nQueens", "@main", 0, None, nPath(1363)))
+  //testLLSC(new PureCPSLLSC_Z3, TestPrg(nqueen, "nQueensZ3", "@main", 0, None, nPath(1363)))
+  testLLSC(new PureLLSC, TestPrg(openTest, "openTestSucc", "@main", 0, "--add-sym-file A", nPath(1)++status(0)))
 }

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -236,5 +236,7 @@ class TestImpCPSLLSC extends TestLLSC {
 }
 
 class Playground extends TestLLSC {
-  //testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
+  testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
+  testLLSC(new ImpLLSC, TestPrg(mergesort, "mergeSortImpTest", "@main", 0, None, nPath(720)))
+  //testLLSC(new PureCPSLLSC, TestPrg(mp1048576, "mp1mTest_CPS", "@f", 20, "--disable-solver", nPath(1048576)))
 }

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -236,7 +236,8 @@ class TestImpCPSLLSC extends TestLLSC {
 }
 
 class Playground extends TestLLSC {
-  testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
+  //testLLSC(new PureCPSLLSC_Z3, TestPrg(mergesort, "mergeSortTest", "@main", 0, None, nPath(720)))
+  //testLLSC(new PureCPSLLSC, memModel)
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(aliasing, "aliasingTest", "@main", 0, None, nPath(1)))
   //testLLSC(new PureCPSLLSC, TestPrg(nqueen, "nQueens", "@main", 0, None, nPath(1363)))
   //testLLSC(new PureCPSLLSC_Z3, TestPrg(nqueen, "nQueensZ3", "@main", 0, None, nPath(1363)))


### PR DESCRIPTION
I still would like to further simplify the way we implement memory operations, making things a bit less obscure and obviously correct under our assumption. To this end, I started a baseline version that is quite close to physical machines:
- Integers are stored as a sequence of bytes (little-endian) in the memory.
- Location/function values take 8 slots in the memory, 7 of those 8 slots are filled with ``shadowed'' values, which don't have semantic meaning but are simply placeholders.
- However, a `Value` not in memory still could be of other sizes, e.g. reading 4 bytes at a location will return an `IntV(n, 32)`. Internally, an `IntV` value still holds a native C integer for convenience. 
- To interoperate between this baseline memory representation and our value representation, each value is equipped with a `to_bytes` (or "unfold") method that reifies the value to a list of bytes, which can be directly used to update memory. In principle, memory read/update should not care about how a specific value is represented in the memory. The dual of "unfold" (ie `fold`) is currently buried in `Mem0::at` which essentially concatenates a sequence of memory-values into a whole/logical value that has the right size. 

  Update: `to_bytes_shadow` can be used to produce the compact bytes layout that makes use of indexed shadow values.
- Location/function values must be read/updated as a whole, i.e. it is undefined to read or update a fragment of location/location values.
- A `is_well_formed` check is being implemented, which should check if values stored in this baseline memory follow our condition.
- Front-end still needs to refactor so that the initial heap is generated correctly.
- After done, we shall use this model as 1) the semantic ground truth so we can check against other variants or refactor, and 2) a performance baseline.

TODO

- [x] Refactor front-end heap generation
- [ ] ~~Properly handle floats~~ (other PR later)
- [x] `make_symbolic_whole(size_t)` that creates whole integers instead of 8bvs.
