### PR TITLE
Add llsc_assume external function

### DIFF
--- a/dev-clean/benchmarks/external_lib/assume.c
+++ b/dev-clean/benchmarks/external_lib/assume.c
@@ -1,0 +1,14 @@
+#include "../../headers/llsc_client.h"
+
+int main() {
+  int x, y, z;
+  make_symbolic(&x, sizeof(x));
+  make_symbolic(&y, sizeof(y));
+  z = llsc_range(0, 10, "z");
+  llsc_assert_eager((z >= 0) && (z < 10));
+  llsc_assume(x < y);
+  if (x >= y) {
+    print_string("Unreachable\n");
+  }
+  sym_print(x, y, z);
+}

--- a/dev-clean/benchmarks/external_lib/klee_fs_mini_packed.c
+++ b/dev-clean/benchmarks/external_lib/klee_fs_mini_packed.c
@@ -1,0 +1,58 @@
+typedef struct {
+  char dummy_packed;
+  unsigned size;  /* in bytes */
+  char* contents;
+} __attribute__((packed)) exe_disk_file_t;
+
+typedef struct {
+  unsigned n_sym_files; /* number of symbolic input files, excluding stdin */
+  exe_disk_file_t *sym_stdin, *sym_stdout;
+  unsigned stdout_writes; /* how many chars were written to stdout */
+  char dummy_packed;
+  exe_disk_file_t *sym_files;
+  /* --- */
+  /* the maximum number of failures on one path; gets decremented after each failure */
+  unsigned max_failures;
+
+  /* Which read, write etc. call should fail */
+  int *read_fail, *write_fail, *close_fail, *ftruncate_fail, *getcwd_fail;
+  int *chmod_fail, *fchmod_fail;
+} __attribute__((packed)) exe_file_system_t;
+
+exe_file_system_t __exe_fs;
+
+static void __create_new_dfile(exe_disk_file_t *dfile, unsigned size) {
+
+  llsc_assert(size);
+
+  dfile->size = size;
+  dfile->contents = malloc(dfile->size);
+  if (!dfile->contents) sym_exit(-1);
+  make_symbolic(dfile->contents, dfile->size);
+}
+
+/* n_files: number of symbolic input files, excluding stdin
+   file_length: size in bytes of each symbolic file, including stdin */
+void klee_init_fds(unsigned n_files, unsigned file_length) {
+  unsigned k;
+
+  __exe_fs.n_sym_files = n_files;
+  __exe_fs.sym_files = malloc(sizeof(*__exe_fs.sym_files) * n_files);
+  if (n_files && !__exe_fs.sym_files) sym_exit(-1);
+
+  for (k=0; k < n_files; k++) {
+    __create_new_dfile(&__exe_fs.sym_files[k], file_length);
+  }
+}
+
+int main()
+{
+  // expected paths: 2
+  klee_init_fds(2, 10);
+  if (__exe_fs.sym_files[1].contents[2]) {
+    sym_print(__exe_fs.sym_files[1].contents[2]);
+  } else {
+    sym_print(__exe_fs.sym_files[1].contents[2]);
+  }
+  return 0;
+}

--- a/dev-clean/benchmarks/llvm/unprintable_char.c
+++ b/dev-clean/benchmarks/llvm/unprintable_char.c
@@ -1,0 +1,17 @@
+#include "../../headers/llsc_client.h"
+
+char b[10] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0};
+char* c = "\\61";
+char d[4] = {0x5c, 0x36, 0x31, 0x00};
+int main(){
+  for (int i=0; i<10;i++) {
+    llsc_assert_eager(b[i] == ((i+1)%10));
+  }
+  for (int i=0; i<4;i++) {
+    llsc_assert_eager(c[i] == d[i]);
+  }
+  llsc_assert_eager(c[0] == 92);
+  llsc_assert_eager(c[1] == 54);
+  llsc_assert_eager(c[2] == 49);
+  llsc_assert_eager(c[3] == 0);
+}

--- a/dev-clean/benchmarks/llvm/varArgCopyInt.c
+++ b/dev-clean/benchmarks/llvm/varArgCopyInt.c
@@ -1,0 +1,52 @@
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <assert.h>
+#include "../../headers/llsc_client.h"
+
+int __add_em_up (int count, va_list ap)
+{
+  int i, sum;
+
+  sum = 0;
+  for (i = 0; i < count; i++)
+    sum += va_arg (ap, int);    /* Get the next argument value. */
+
+  return sum;
+}
+
+int add_em_up (int count, ...)
+{
+  va_list ap, copy;
+  int i, sum;
+
+  va_start (ap, count);         /* Initialize the argument list. */
+  va_copy (copy, ap);
+
+  sum = 0;
+  for (i = 0; i < count; i++)
+    sum += va_arg (ap, int);    /* Get the next argument value. */
+
+  va_end (ap);                  /* Clean up. */
+
+  sum += __add_em_up(count, copy);
+  va_end (copy);
+  return sum;
+}
+
+int main (void) {
+  /* This call prints 32. */
+  // printf ("%d\n", add_em_up (3, 5, 5, 6));
+  int sum = 0;
+  sum = add_em_up (3, 5, 5, 6);
+  sym_print(sum);
+  llsc_assert_eager(32 == sum);
+
+  /* This call prints 110. */
+  // printf ("%d\n", add_em_up (10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+  sum = add_em_up (10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  sym_print(sum);
+  llsc_assert_eager(110 == sum);
+
+  return 0;
+}

--- a/dev-clean/headers/llsc/external_imp.hpp
+++ b/dev-clean/headers/llsc/external_imp.hpp
@@ -210,5 +210,39 @@ inline T __llvm_va_end(SS& state, List<PtrVal>& args, __Cont<T> k) {
   }
   return k(state, IntV0);
 }
+template<typename T>
+inline T __llvm_va_copy(SS& state, List<PtrVal>& args, __Cont<T> k) {
+  PtrVal dst_va_list = args.at(0);
+  PtrVal src_va_list = args.at(1);
+  ASSERT(std::dynamic_pointer_cast<LocV>(dst_va_list) != nullptr, "Dest valist Non-location value");
+  ASSERT(std::dynamic_pointer_cast<LocV>(src_va_list) != nullptr, "Src valist Non-location value");
+  ASSERT(std::dynamic_pointer_cast<LocV>(state.at(src_va_list + 16, 8)) != nullptr, "Src valist must be initialized");
+  state.update(dst_va_list + 0, state.at(src_va_list + 0, 4), 4);
+  state.update(dst_va_list + 4, state.at(src_va_list + 4, 4), 4);
+  state.update(dst_va_list + 8, state.at(src_va_list + 8, 8), 8);
+  state.update(dst_va_list + 16, state.at(src_va_list + 16, 8), 8);
+  return k(state, IntV0);
+}
+
+/******************************************************************************/
+
+template<typename T>
+inline T __llsc_assume(SS& state, List<PtrVal>& args, __Cont<T> k, __Halt<T> h) {
+  auto v = args.at(0);
+  auto i = v->to_IntV();
+  if (i) {
+    if (i->i == 0) return h(state, { make_IntV(-1) }); // concrete false - generate the test and ``halt''
+    return k(state, make_IntV(1, 32));
+  }
+  // otherwise add a symbolic condition that constraints it to be true
+  // undefined/error if v is a value of other types
+  ASSERT(std::dynamic_pointer_cast<SymV>(v) != nullptr, "Non-Symv");
+  auto cond = v;
+  auto pc = state.get_PC();
+  pc.add(cond);
+  if (!check_pc(pc)) return h(state, { make_IntV(-1) }); // check if v == 1 is satisfiable
+  state.set_PC(pc);
+  return k(state, make_IntV(1, 32));
+}
 
 #endif

--- a/dev-clean/headers/llsc/external_shared.hpp
+++ b/dev-clean/headers/llsc/external_shared.hpp
@@ -158,6 +158,9 @@ inline T __llvm_va_start(SS& state, List<PtrVal>& args, __Cont<T> k);
 template<typename T>
 inline T __llvm_va_end(SS& state, List<PtrVal>& args, __Cont<T> k);
 
+template<typename T>
+inline T __llvm_va_copy(SS& state, List<PtrVal>& args, __Cont<T> k);
+
 inline List<SSVal> llvm_va_start(SS state, List<PtrVal> args) {
   return __llvm_va_start<List<SSVal>>(state, args, [](auto s, auto v) { return List<SSVal>{{s, v}}; });
 }
@@ -172,6 +175,31 @@ inline List<SSVal> llvm_va_end(SS state, List<PtrVal> args) {
 
 inline std::monostate llvm_va_end(SS state, List<PtrVal> args, Cont k) {
   return __llvm_va_end<std::monostate>(state, args, [&k](auto s, auto v) { return k(s, v); });
+}
+
+inline List<SSVal> llvm_va_copy(SS state, List<PtrVal> args) {
+  return __llvm_va_copy<List<SSVal>>(state, args, [](auto s, auto v) { return List<SSVal>{{s, v}}; });
+}
+
+inline std::monostate llvm_va_copy(SS state, List<PtrVal> args, Cont k) {
+  return __llvm_va_copy<std::monostate>(state, args, [&k](auto s, auto v) { return k(s, v); });
+}
+
+/******************************************************************************/
+
+template<typename T>
+inline T __llsc_assume(SS& state, List<PtrVal>& args, __Cont<T> k, __Halt<T> h);
+
+inline List<SSVal> llsc_assume(SS state, List<PtrVal> args) {
+  return __llsc_assume<List<SSVal>>(state, args,
+      [](auto s, auto v) { return List<SSVal>{{s, v}}; },
+      [](auto s, auto a) { return sym_exit(s, a); });
+}
+
+inline std::monostate llsc_assume(SS state, List<PtrVal> args, Cont k) {
+  return __llsc_assume<std::monostate>(state, args,
+      [&k](auto s, auto v) { return k(s, v); },
+      [&k](auto s, auto a) { return sym_exit(s, a, k); });
 }
 
 #endif

--- a/dev-clean/headers/llsc_client.h
+++ b/dev-clean/headers/llsc_client.h
@@ -14,11 +14,31 @@ void make_symbolic(void* addr, size_t byte_size);
  */
 void make_symbolic_whole(void* addr, size_t byte_size);
 
+#define llsc_make_symbolic(addr, byte_size, name) make_symbolic(addr, byte_size);
+
 void llsc_assert(bool);
 void llsc_assert_eager(bool);
 
+void llsc_assume(bool);
+
 void print_string(const char *message);
 
+/* llsc_range - Construct a symbolic value in the signed interval
+ * [begin,end).
+ *
+ * \arg name - A name used for identifying the object in messages, output
+ * files, etc. If NULL, object is called "unnamed".
+ */
+static inline int llsc_range(int begin, int end, const char *name) {
+  int x;
+  make_symbolic_whole(&x, sizeof(x));
+  llsc_assume(x >= begin);
+  llsc_assume(x < end);
+  return x;
+}
+
+__attribute__((noreturn))
+void stop(int status);
 /* llsc_report_error - Report a user defined error and terminate the current
  * llsc process.
  *
@@ -36,12 +56,16 @@ static inline void llsc_report_error(const char *file,
   sym_print(line);
   print_string(message);
   print_string(suffix);
+  print_string("\n");
   stop(-1);
 }
 
 static inline void llsc_warning(const char *message) {
   print_string(message);
+  print_string("\n");
 }
+
+#define llsc_warning_once(message) llsc_warning(message)
 
 /* Support for runing test-comp examples */
 

--- a/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
+++ b/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
@@ -47,6 +47,7 @@ object Benchmarks {
   lazy val global = parseFile("benchmarks/llvm/global.ll")
   lazy val varArgChar = parseFile("benchmarks/llvm/varArgChar.ll")
   lazy val varArgInt = parseFile("benchmarks/llvm/varArgInt.ll")
+  lazy val varArgCopyInt = parseFile("benchmarks/llvm/varArgCopyInt.ll")
   lazy val trunc = parseFile("benchmarks/llvm/trunc.ll")
   lazy val floatArith = parseFile("benchmarks/llvm/floatArith.ll")
   lazy val floatFp80 = parseFile("benchmarks/llvm/floatFp80.ll")
@@ -81,14 +82,18 @@ object Benchmarks {
   lazy val write1Test = parseFile("benchmarks/external_lib/write1.ll")
   lazy val stat1Test = parseFile("benchmarks/external_lib/stat1.ll")
   lazy val stat2Test = parseFile("benchmarks/external_lib/stat2.ll")
+  lazy val assumeTest = parseFile("benchmarks/external_lib/assume.ll")
 
   lazy val kleefsminiTest = parseFile("benchmarks/external_lib/klee_fs_mini.ll")
+  lazy val kleefsminiPackedTest = parseFile("benchmarks/external_lib/klee_fs_mini_packed.ll")
   lazy val kleefsglobalTest = parseFile("benchmarks/external_lib/klee_fs_mini_global.ll")
   lazy val kleefslib64Test = parseFile("benchmarks/klee_fs_lib/klee_lib_64.ll")
   // lazy val openAtTest = parseFile("benchmarks/external_lib/openat.ll")
 
   lazy val argv1Test = parseFile("benchmarks/llvm/argv1.ll")
   lazy val argv2Test = parseFile("benchmarks/llvm/argv2.ll")
+
+  lazy val unprintableCharTest = parseFile("benchmarks/llvm/unprintable_char.ll")
 }
 
 object TestComp {

--- a/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
+++ b/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
@@ -158,6 +158,33 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
     }
   }
 
+  object PackedStructCalc {
+    private def padding(size: Int, align: Int): Int = 0
+
+    private def fields(types: List[LLVMType]): (Int, Int, Int) =
+      types.foldLeft((0, 0, 0)) { case ((begin, end, maxalign), ty) =>
+        val (size, align) = getTySizeAlign(ty)
+        val new_begin = end + padding(end, align)
+        (new_begin, new_begin + size, 1)
+      }
+
+    def getSizeAlign(types: List[LLVMType]): (Int, Int) = {
+      val (_, size, align) = fields(types)
+      (size + padding(size, align), 1)
+    }
+
+    def getFieldOffset(types: List[LLVMType], idx: Int): Int =
+      fields(types.take(idx+1))._1
+
+    def concat[E](cs: List[E])(feval: E => (List[Rep[Value]], Int)): (List[Rep[Value]], Int) = {
+      val (list, align) = cs.foldLeft((StaticList[Rep[Value]](), 0)) { case ((list, maxalign), c) =>
+        val (value, align) = feval(c)
+        (list ++ value, 1)
+      }
+      (list, 1)
+    }
+  }
+
   def getTySizeAlign(vt: LLVMType): (Int, Int) = vt match {
     case ArrayType(num, ety) =>
       val (size, align) = getTySizeAlign(ety)
@@ -186,7 +213,7 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
       (elemSize, elemSize)
     }
     case PackedStruct(types) =>
-      (types.map(getTySizeAlign(_)._1).sum, 1)
+      PackedStructCalc.getSizeAlign(types)
     case _ =>
       throw new Exception(s"type $vt is not handled by getTySizeAlign")
   }
@@ -205,6 +232,9 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
         calculateOffsetStatic(typeDefMap(id), index)
       case PtrType(ety, addrSpace) =>
         index.head * getTySize(ety) + calculateOffsetStatic(ety, index.tail)
+      case PackedStruct(types) =>
+        val prev: Int = PackedStructCalc.getFieldOffset(types, index.head)
+        prev + calculateOffsetStatic(types(index.head), index.tail)
       case _ => ???
     }
   }
@@ -223,6 +253,9 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
         //  constants are allowed"
         // TODO: the align argument for getTySize
         // TODO: test this
+        val indexCst: List[Long] = index.map { case Wrap(Backend.Const(n: Long)) => n.toLong }
+        calculateOffsetStatic(ty, indexCst)
+      case PackedStruct(types) =>
         val indexCst: List[Long] = index.map { case Wrap(Backend.Const(n: Long)) => n.toLong }
         calculateOffsetStatic(ty, indexCst)
       case _ => ???
@@ -248,7 +281,7 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
     case NullConst => LocV(0.toLong, LocV.kHeap)
     case PtrToIntExpr(from, const, to) =>
       val v = evalHeapAtomicConst(const, from).toIntV
-      if (ARCH_WORD_SIZE == to.asInstanceOf[IntType].size) 
+      if (ARCH_WORD_SIZE == to.asInstanceOf[IntType].size)
         v.toIntV
       else
         v.toIntV.trunc(ARCH_WORD_SIZE, to.asInstanceOf[IntType].size)
@@ -267,8 +300,15 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
 
   def evalHeapComplexConst(v: Constant, real_ty: LLVMType): (List[Rep[Value]], Int) = {
     v match {
-      case StructConst(cs) =>
-        StructCalc.concat(cs) { c => evalHeapConstWithAlign(c.const, c.ty) }
+      case StructConst(cs) => {
+        real_ty match {
+          case Struct(types) =>
+            StructCalc.concat(cs) { c => evalHeapConstWithAlign(c.const, c.ty) }
+          case PackedStruct(types) =>
+            PackedStructCalc.concat(cs) { c => evalHeapConstWithAlign(c.const, c.ty) }
+          case _ => ???
+        }
+      }
       case ArrayConst(cs) =>
         cs.foldLeft((StaticList[Rep[Value]](), 0)) { case ((l0, a0), c) =>
           val va = evalHeapConstWithAlign(c.const, c.ty)
@@ -283,6 +323,8 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
           (StaticList.fill(size)(value).flatten, align)
         case Struct(types) =>
           StructCalc.concat(types) { evalHeapConstWithAlign(ZeroInitializerConst, _) }
+        case PackedStruct(types) =>
+          PackedStructCalc.concat(types) { evalHeapConstWithAlign(ZeroInitializerConst, _) }
         // TODO: fallback case is not typed
         case _ =>
           val (size, align) = getTySizeAlign(real_ty)
@@ -294,6 +336,8 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
           (StaticList.fill(size)(value).flatten, align)
         case Struct(types) =>
           StructCalc.concat(types) { evalHeapConstWithAlign(UndefConst, _) }
+        case PackedStruct(types) =>
+          PackedStructCalc.concat(types) { evalHeapConstWithAlign(UndefConst, _) }
         // TODO: fallback case is not typed
         case _ =>
           val (size, align) = getTySizeAlign(real_ty)

--- a/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
+++ b/dev-clean/src/main/scala/sai/llsc/EngineBase.scala
@@ -159,18 +159,15 @@ trait EngineBase extends SAIOps { self: BasicDefs with ValueDefs =>
   }
 
   object PackedStructCalc {
-    private def padding(size: Int, align: Int): Int = 0
-
-    private def fields(types: List[LLVMType]): (Int, Int, Int) =
-      types.foldLeft((0, 0, 0)) { case ((begin, end, maxalign), ty) =>
-        val (size, align) = getTySizeAlign(ty)
-        val new_begin = end + padding(end, align)
-        (new_begin, new_begin + size, 1)
+    private def fields(types: List[LLVMType]): (Int, Int) =
+      types.foldLeft((0, 0)) { case ((begin, end), ty) =>
+        val size = getTySizeAlign(ty)._1
+        (end, end + size)
       }
 
     def getSizeAlign(types: List[LLVMType]): (Int, Int) = {
-      val (_, size, align) = fields(types)
-      (size + padding(size, align), 1)
+      val size = fields(types)._2
+      (size, 1)
     }
 
     def getFieldOffset(types: List[LLVMType], idx: Int): Int =

--- a/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
@@ -182,7 +182,7 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
       case PtrToIntInst(from, value, to) =>
         import Constants._
         for { v <- eval(value, from) } yield
-          if (ARCH_WORD_SIZE == to.asInstanceOf[IntType].size) 
+          if (ARCH_WORD_SIZE == to.asInstanceOf[IntType].size)
             v.toIntV
           else
             v.toIntV.trunc(ARCH_WORD_SIZE, to.asInstanceOf[IntType].size)

--- a/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
@@ -80,7 +80,7 @@ trait Opaques { self: SAIOps with BasicDefs =>
       "sym_print", "print_string", "malloc", "realloc",
       "llsc_assert", "llsc_assert_eager", "__assert_fail", "sym_exit",
       "make_symbolic", "make_symbolic_whole",
-      "open", "close", "read", "write", "stat", "stop", "syscall"
+      "open", "close", "read", "write", "stat", "stop", "syscall", "llsc_assume"
     )
     def apply(f: String): Rep[Value] = {
       if (!used.contains(f)) {
@@ -97,6 +97,7 @@ trait Opaques { self: SAIOps with BasicDefs =>
       if (modeled.contains(id.tail)) ExternalFun(id.tail)
       else if (id.startsWith("@llvm.va_start")) ExternalFun("llvm_va_start")
       else if (id.startsWith("@llvm.va_end")) ExternalFun("llvm_va_end")
+      else if (id.startsWith("@llvm.va_copy")) ExternalFun("llvm_va_copy")
       else if (id.startsWith("@llvm.memcpy")) ExternalFun("llvm_memcpy")
       else if (id.startsWith("@llvm.memset")) ExternalFun("llvm_memset")
       else if (id.startsWith("@llvm.memmove")) ExternalFun("llvm_memset")

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -69,6 +69,8 @@ object TestCases {
     TestPrg(structReturnLong, "structReturnLongTest", "@main", noArg, None, nPath(1)),
     TestPrg(structAccess, "structAccessTest", "@main", noArg, None, nPath(1)),
     TestPrg(structReturn, "structReturnTest", "@main", noArg, None, nPath(1)),
+
+    TestPrg(unprintableCharTest, "unprintableCharTest", "@main", noArg, None, nPath(1)++status(0)),
   )
 
   val memModel: List[TestPrg] = List(
@@ -86,7 +88,8 @@ object TestCases {
   )
 
   val varArg: List[TestPrg] = List(
-    TestPrg(varArgInt, "varArgInt", "@main", noArg, None, nPath(1)++status(0))
+    TestPrg(varArgInt, "varArgInt", "@main", noArg, None, nPath(1)++status(0)),
+    TestPrg(varArgCopyInt, "varArgCopyInt", "@main", noArg, None, nPath(1)++status(0)),
     // FIXME(PureLLSC): Sext an invalid value
     // TestPrg(varArgChar, "varArgChar", "@main", noArg, None, nPath(1))
   )
@@ -121,6 +124,7 @@ object TestCases {
   val external: List[TestPrg] = List(
     TestPrg(assertTest, "assertTest", "@main", noArg, None, minPath(3)),
     TestPrg(assertfixTest, "assertfix", "@main", noArg, None, nPath(4)),
+    TestPrg(assumeTest, "assumeTest", "@main", noArg, None, nPath(1)++status(0)),
   )
 
   val filesys: List[TestPrg] = List(
@@ -134,6 +138,7 @@ object TestCases {
     TestPrg(stat2Test, "statTestRead", "@main", noArg, "--add-sym-file A", nPath(3)++status(0)),
     TestPrg(stat2Test, "statTestFail", "@main", noArg, "", nPath(1)++status(1)),
     TestPrg(kleefsminiTest, "kleefsmini", "@main", noArg, None, nPath(2)++status(0)),
+    TestPrg(kleefsminiPackedTest, "kleefsminiPackedTest", "@main", noArg, None, nPath(2)++status(0)),
     TestPrg(kleefsglobalTest, "kleefsminiglobal", "@main", noArg, None, nPath(2)++status(0)),
     TestPrg(kleefslib64Test, "kleelib64", "@main", noArg, None, nPath(10)++status(0)),
   )


### PR DESCRIPTION
Add llvm.va_copy intrinsic
Add support for Packed struct
Fix: fix error in parsing llvm string, replace all un-printable symbol
Fix: rewrite visitTypeConstList in tail-recursive way (more efficient in dealing with large const array, avoid stack over flow)
Fix: handle store instruction with no alignment.