### PR TITLE
* fix switch, discard infeasible branches

### DIFF
--- a/dev-clean/benchmarks/llvm/switchTestSym.c
+++ b/dev-clean/benchmarks/llvm/switchTestSym.c
@@ -1,6 +1,9 @@
+#include "../../headers/llsc_client.h"
 int main() {
   int a;
   make_symbolic(&a, 4);
+  llsc_assume(a > 2);
+  llsc_assume(a < 8);
   switch (a) {
     case 1:
       assert();
@@ -12,6 +15,18 @@ int main() {
       assert();
       break;
     case 4:
+      assert();
+      break;
+    case 5:
+      assert();
+      break;
+    case 6:
+      assert();
+      break;
+    case 7:
+      assert();
+      break;
+    case 8:
       assert();
       break;
     default:

--- a/dev-clean/headers/llsc/filesys.hpp
+++ b/dev-clean/headers/llsc/filesys.hpp
@@ -218,7 +218,7 @@ class FS: public Printable {
   private:
     immer::map<Fd, Stream> opened_files;
     /* TODO: implement directory structure
-     * 1. change the string key to a fileId, similar to inode number 
+     * 1. change the string key to a fileId, similar to inode number
      * 2. add a root directory file, with fileId=0
      * <2022-02-08, David Deng> */
     immer::map<std::string, File> files;

--- a/dev-clean/src/main/scala/sai/conc/Codegen.scala
+++ b/dev-clean/src/main/scala/sai/conc/Codegen.scala
@@ -21,7 +21,7 @@ trait SymStagedLLVMGen extends CppSAICodeGenBase {
   val codegenFolder: String
 
   override def quote(s: Def): String = s match {
-    case Sym(n) if n == FunName.conc_exec => "conc_exec" 
+    case Sym(n) if n == FunName.conc_exec => "conc_exec"
     case Sym(n) =>
       FunName.funMap.getOrElse(n, {
         FunName.blockMap.getOrElse(n, super.quote(s))

--- a/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
+++ b/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
@@ -110,6 +110,9 @@ object Benchmarks {
   lazy val link_linked = parseFile("benchmarks/coreutils/link_linked.ll")
   lazy val paste_linked = parseFile("benchmarks/coreutils/paste_linked.ll")
   lazy val pathchk_linked = parseFile("benchmarks/coreutils/pathchk_linked.ll")
+
+  lazy val echo_llsc_linked = parseFile("benchmarks/coreutils/echo_llsc_linked.ll")
+  lazy val true_llsc_linked = parseFile("benchmarks/coreutils/true_llsc_linked.ll")
 }
 
 object TestComp {

--- a/dev-clean/src/main/scala/sai/llsc/Transform.scala
+++ b/dev-clean/src/main/scala/sai/llsc/Transform.scala
@@ -46,7 +46,7 @@ object AssignElim {
         Const(())
       case Node(s, "ss-assign", StaticList(ss: Sym, Const(x: Int), v), _) if eliminable(x) =>
         Const(())
-      case Node(s, "ss-alloc-stack", StaticList(ss: Exp, Const(n1: Mut[Int])), _) 
+      case Node(s, "ss-alloc-stack", StaticList(ss: Exp, Const(n1: Mut[Int])), _)
           if g.curEffects.allEff.contains(transform(ss)) =>
         for ((k, _) <- g.curEffects.allEff(transform(ss))) {
           g.findDefinition(k) collect {

--- a/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
@@ -64,9 +64,15 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
       case GlobalId(id) if symDefMap.contains(id) =>
         System.out.println(s"Alias: $id => ${symDefMap(id).const}")
         eval(symDefMap(id).const, ty, ss)
-      case GlobalId(id) if funMap.contains(id) =>
-        if (!FunFuns.contains(id)) compile(funMap(id))
-        CPSFunV[Id](FunFuns(id))
+      case GlobalId(id) if funMap.contains(id) => {
+        if (ExternalFun.rederict.contains(id)) {
+          val t = funMap(id).header.returnType
+          ExternalFun.get(id, Some(t))
+        } else {
+          if (!FunFuns.contains(id)) compile(funMap(id))
+          CPSFunV[Id](FunFuns(id))
+        }
+      }
       case GlobalId(id) if funDeclMap.contains(id) =>
         val t = funDeclMap(id).header.returnType
         ExternalFun.get(id, Some(t))
@@ -289,15 +295,26 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
             execBlock(funName, default, s.addPCSet(pc), k)
           } else {
             val headPC = IntOp2("eq", v, IntV(table.head.n))
-            execBlock(funName, table.head.label, s.addPC(headPC.toSMTBool), k)
-            switchSym(v, s, table.tail, pc ++ List[SMTBool](headPC.toSMTBoolNeg))
+
+            val t_sat = checkPC(s.pc.addPC(headPC.toSMTBool))
+            val f_sat = checkPC(s.pc.addPC(headPC.toSMTBoolNeg))
+
+            if (t_sat && f_sat) {
+              Coverage.incPath(1)
+            }
+
+            if (t_sat) {
+              execBlock(funName, table.head.label, s.addPC(headPC.toSMTBool), k)
+            }
+            if (f_sat) {
+              switchSym(v, s.addPC(headPC.toSMTBoolNeg), table.tail, pc ++ List[SMTBool](headPC.toSMTBoolNeg))
+            }
           }
 
         val ss1 = addIncomingBlockOpt(ss, incomingBlock, default::table.map(_.label))
         val v = eval(cndVal, cndTy, ss1)
         if (v.isConc) switch(v.int, ss1, table)
         else {
-          Coverage.incPath(table.size)
           switchSym(v, ss1, table)
         }
     }

--- a/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
@@ -27,6 +27,7 @@ trait BasicDefs { self: SAIOps =>
   trait Value
   trait Stack
   trait SS
+  trait PC
   trait FS
   trait File
   trait Stream
@@ -34,7 +35,6 @@ trait BasicDefs { self: SAIOps =>
   type IntData = Long
   type BlockLabel = Int
   type Addr = Long
-  type PC = Set[SMTBool]
   type Id[T] = T
   type Fd = Int
   val bConst = Backend.Const
@@ -90,6 +90,7 @@ trait Opaques { self: SAIOps with BasicDefs =>
       "open", "close", "read", "write", "lseek", "stat", "stop", "syscall", "llsc_assume",
       "__errno_location", "_exit", "abort", "calloc"
     )
+    val rederict = scala.collection.immutable.Set[String]("@memcpy", "@memset", "@memmove")
     def apply(f: String, ret: Option[LLVMType] = None): Rep[Value] = {
       if (!used.contains(f)) {
         System.out.println(s"Use external function $f.")
@@ -108,7 +109,10 @@ trait Opaques { self: SAIOps with BasicDefs =>
       else if (id.startsWith("@llvm.va_copy")) ExternalFun("llvm_va_copy")
       else if (id.startsWith("@llvm.memcpy")) ExternalFun("llvm_memcpy")
       else if (id.startsWith("@llvm.memset")) ExternalFun("llvm_memset")
-      else if (id.startsWith("@llvm.memmove")) ExternalFun("llvm_memset")
+      else if (id.startsWith("@llvm.memmove")) ExternalFun("llvm_memmove")
+      else if (id.startsWith("@memcpy")) ExternalFun("llvm_memcpy")
+      else if (id.startsWith("@memset")) ExternalFun("llvm_memset")
+      else if (id.startsWith("@memmove")) ExternalFun("llvm_memmove")
       else {
         if (!warned.contains(id)) {
           System.out.println(s"External function ${id.tail} is treated as a noop.")

--- a/dev-clean/src/main/scala/sai/llsc/states/ImpSymExeState.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/ImpSymExeState.scala
@@ -66,6 +66,10 @@ trait ImpSymExeDefs extends SAIOps with BasicDefs with ValueDefs with Opaques wi
 
   def currentMethodName: String = Thread.currentThread.getStackTrace()(2).getMethodName
 
+  implicit class PCOps(pc: Rep[PC]) {
+    def addPC(e: Rep[SMTBool]): Rep[Unit] = reflectWrite[Unit]("add-pc", pc, e)(pc)
+  }
+
   implicit class SSOps(ss: Rep[SS]) {
     // Caveat: in the presence of higher-order function (e.g. flatMap, fold),
     // since we currently lack of aliases information, simply using reflectWrite
@@ -113,7 +117,7 @@ trait ImpSymExeDefs extends SAIOps with BasicDefs with ValueDefs with Opaques wi
     def pop(keep: Rep[Int]): Rep[Unit] = reflectWrite[Unit]("ss-pop", ss, keep)(ss, Adapter.CTRL)
     def addPC(e: Rep[SMTBool]): Rep[Unit] = reflectWrite[Unit]("ss-addpc", ss, e)(ss)
     def addPCSet(es: Rep[List[SMTBool]]): Rep[Unit] = reflectWrite[Unit]("ss-addpcset", ss, es)(ss)
-    def pc: Rep[PC] = "get-pc".reflectWith[PC](ss)
+    def pc: Rep[PC] = reflectRead[PC]("get-pc", ss)(ss)
     def updateArg: Rep[Unit] = reflectWrite[Unit]("ss-arg", ss)(ss)
     def updateErrorLoc: Rep[Unit] = reflectWrite[Unit]("ss-error-loc", ss)(ss)
 

--- a/dev-clean/src/main/scala/sai/llsc/states/SymExeState.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/SymExeState.scala
@@ -69,6 +69,10 @@ trait SymExeDefs extends SAIOps with StagedNondet with BasicDefs with ValueDefs 
     } yield ssu._2
   }
 
+  implicit class PCOps(pc: Rep[PC]) {
+    def addPC(e: Rep[SMTBool]): Rep[PC] = "add-pc".reflectWith[PC](pc, e)
+  }
+
   class SSOps(ss: Rep[SS]) {
     private def assignSeq(xs: List[Int], vs: Rep[List[Value]]): Rep[SS] =
       "ss-assign-seq".reflectWith[SS](ss, xs, vs)

--- a/dev-clean/src/test/scala/sai/llsc/OptExperiment.scala
+++ b/dev-clean/src/test/scala/sai/llsc/OptExperiment.scala
@@ -43,7 +43,7 @@ class Optimization extends TestLLSC {
       for (i <- 1 to N) {
         Thread.sleep(1 * 1000)
         val prefix = "numactl -N1 -m1"
-        val (output, ret) = code.runWithStatus(cliArgOpt.getOrElse(""), prefix)
+        val (output, ret) = code.runWithStatus(cliArgOpt.getOrElse(Seq()), prefix)
         val resStat = parseOutput(llsc.insName, name, output)
         System.out.println(resStat)
         writer.append(s"$resStat\n")

--- a/dev-clean/src/test/scala/sai/llsc/TestCases.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestCases.scala
@@ -25,7 +25,7 @@ import Config._
  * runOpt: the command line argument to run the compiled executable
  * result: expected return status of the compiled executable
  */
-case class TestPrg(m: Module, name: String, f: String, config: Config, runOpt: Option[String], exp: Map[String, Any])
+case class TestPrg(m: Module, name: String, f: String, config: Config, runOpt: Option[Seq[String]], exp: Map[String, Any])
 
 object TestPrg {
   val nPath = "nPath"
@@ -40,6 +40,10 @@ object TestPrg {
   def status(n: Int): Map[String, Any] = Map(status -> n)
 
   implicit def lift[T](t: T): Option[T] = Some(t)
+
+  def apply(m: Module, name: String, f: String, config: Config, runOpt: String, exp: Map[String, Any]) = {
+    new TestPrg(m, name, f, config, runOpt.split("\\s+").toSeq, exp)
+  }
 }
 
 import TestPrg._

--- a/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestLLSC.scala
@@ -54,9 +54,9 @@ abstract class TestLLSC extends FunSuite {
     test(name) {
       val code = llsc.newInstance(m, llsc.insName + "_" + name, f, config)
       code.genAll
-      val mkRet = code.make(4)
+      val mkRet = if(config.test_coreutil) code.make_all_cores else code.make(4)
       assert(mkRet == 0, "make failed")
-      val (output, ret) = code.runWithStatus(cliArgOpt.getOrElse(""))
+      val (output, ret) = code.runWithStatus(cliArgOpt.getOrElse(Seq()))
       System.err.println(output)
       val resStat = parseOutput(llsc.insName, name, output)
       System.err.println(resStat)
@@ -119,6 +119,9 @@ class Playground extends TestLLSC {
   //testLLSC(new PureCPSLLSC, TestPrg(mp1048576, "mp1mTest_CPS", "@f", symArg(20), "--disable-solver", nPath(1048576)))
   val llsc = new PureCPSLLSC_Z3
   //testLLSC(llsc, TestPrg(mergesort, "mergeSortTest", "@main", noArg, None, nPath(720)))
+  //testLLSC(new PureLLSC, List(TestPrg(echo_linked, "echo_linked_posix", "@main", testcoreutil, Seq("--cons-indep","--argv=./true.bc --sym-stdout --sym-arg 8"), nPath(4971)++status(0))))
+  //testLLSC(new PureCPSLLSC, List(TestPrg(echo_linked, "echo_linked_posix", "@main", testcoreutil, Seq("--cons-indep","--argv=./true.bc --sym-stdout --sym-arg 8"), nPath(4971)++status(0))))
+  //testLLSC(new PureLLSC, List(TestPrg(echo_llsc_linked, "echo_llsc_linked", "@main", testcoreutil, Seq("--cons-indep","--argv=./true.bc #{3}"), nPath(26)++status(0))))
   //testLLSC(llsc, TestPrg(mp1048576, "mp1mTest", "@f", symArg(20), "--disable-solver", nPath(1048576)))
   //testLLSC(llsc, TestPrg(parseFile("benchmarks/demo_benchmarks/nqueen_opt.ll"), "nQueensOpt", "@main", noArg, None, nPath(1363)))
   //testLLSC(new PureLLSC, List(TestPrg(true_linked, "true_linked", "@main", useArgv, "--argv=./true.bc --sym-arg 3", nPath(16)++status(0))))


### PR DESCRIPTION
* change optimization flag of cpp compilation for coreutils program, O0
for main file, O3 for others

* use all cores for coreutils's make

* redirect memcpy, memset, memmove into internal intrinsic

* refactor ommand line argument passing, use Seq[String] instead of
String