### PR TITLE
i1 as bitvector

### DIFF
--- a/dev-clean/benchmarks/llvm/i1_bitvector.c
+++ b/dev-clean/benchmarks/llvm/i1_bitvector.c
@@ -1,0 +1,33 @@
+#include "../../headers/llsc_client.h"
+
+int main() {
+  int a;
+  make_symbolic(&a, 4);
+  llsc_assume(a >= 0);
+
+  //The condition of the while loop will be compiled into the following ir.
+  /*
+  %2 = load i32, i32* %a, align 4
+  %cmp1 = icmp sgt i32 %2, 3
+  %lnot = xor i1 %cmp1, true
+  br i1 %lnot, label %while.body, label %while.end
+  */
+  //which means we will perform arithmetic operation on i1
+  while (!(a > 3)) {
+    a++;
+  }
+
+
+  bool b1 = !(a > 3);
+  //The condition of the if statement will be compiled into the following ir.
+  /*
+  %5 = load i8, i8* %b1, align 1
+  %tobool = trunc i8 %5 to i1
+  br i1 %tobool, label %if.then, label %if.end
+  */
+  //which means the condition of the branch instruction maybe a truncated i1 value
+  if (b1) {
+    sym_exit(-1);
+  }
+  return 0;
+}

--- a/dev-clean/headers/llsc/auxiliary.hpp
+++ b/dev-clean/headers/llsc/auxiliary.hpp
@@ -44,7 +44,7 @@ enum class iOP {
   op_sge, op_sgt, op_sle, op_slt, op_neq,
   op_shl, op_lshr, op_ashr, op_and, op_or, op_xor,
   op_urem, op_srem, op_neg, op_sext, op_zext, op_trunc,
-  op_concat, op_extract
+  op_concat, op_extract, op_bool2bv
 };
 
 enum class fOP {
@@ -63,6 +63,32 @@ inline void set_exit_code(int code) {
   if (!exit_code.load().has_value()) {
     exit_code.store(std::make_optional<int>(code));
   }
+}
+
+inline bool is_binary_op_bool(iOP op) {
+  switch (op) {
+    case iOP::op_eq:
+    case iOP::op_neq:
+    case iOP::op_uge:
+    case iOP::op_sge:
+    case iOP::op_ugt:
+    case iOP::op_sgt:
+    case iOP::op_ule:
+    case iOP::op_sle:
+    case iOP::op_ult:
+    case iOP::op_slt:
+      return true;
+    default:
+      return false;
+  }
+}
+
+inline bool is_unary_op_bool(iOP op) {
+  return iOP::op_neg == op;
+}
+
+inline bool is_op_bool(iOP op) {
+  return is_binary_op_bool(op) || is_unary_op_bool(op);
 }
 
 inline std::string int_op2string(iOP op) {
@@ -96,6 +122,7 @@ inline std::string int_op2string(iOP op) {
     case iOP::op_trunc: return "trunc";
     case iOP::op_concat: return "concat";
     case iOP::op_extract: return "extract";
+    case iOP::op_bool2bv: return "booltobv";
   }
   return "unknown op";
 }

--- a/dev-clean/headers/llsc/smt_z3.hpp
+++ b/dev-clean/headers/llsc/smt_z3.hpp
@@ -53,8 +53,6 @@ public:
   expr construct_z3_expr(context* c, PtrVal e) {
     auto int_e = std::dynamic_pointer_cast<IntV>(e);
     if (int_e) {
-      if (int_e->bw == 1)
-        return c->bool_val(int_e->i ? true : false);
       return c->bv_val(int_e->as_signed(), int_e->bw);
     }
     auto sym_e = std::dynamic_pointer_cast<SymV>(e);

--- a/dev-clean/headers/llsc/smt_z3.hpp
+++ b/dev-clean/headers/llsc/smt_z3.hpp
@@ -101,8 +101,7 @@ public:
         return !expr_rands.at(0);
       case iOP::op_sext: {
         auto v = expr_rands.at(0);
-        if (v.get_sort().is_bool())
-          v = ite(v, c->bv_val(1, 1), c->bv_val(0, 1));
+        ASSERT(!v.get_sort().is_bool(), "Extend a boolean formula");
         auto ext_size = bw - v.get_sort().bv_size();
         ASSERT(ext_size >= 0, "negative sign extension size");
         if (ext_size > 0) return sext(v, ext_size);
@@ -110,8 +109,7 @@ public:
       }
       case iOP::op_zext: {
         auto v = expr_rands.at(0);
-        if (v.get_sort().is_bool())
-          v = ite(v, c->bv_val(1, 1), c->bv_val(0, 1));
+        ASSERT(!v.get_sort().is_bool(), "Extend a boolean formula");
         auto ext_size = bw - v.get_sort().bv_size();
         ASSERT(ext_size >= 0, "negative zero extension size");
         if (ext_size > 0) return zext(v, ext_size);
@@ -142,6 +140,11 @@ public:
         return expr_rands.at(0).extract(
                                 expr_rands.at(1).get_numeral_uint(),
                                 expr_rands.at(2).get_numeral_uint());
+      case iOP::op_bool2bv: {
+        auto v = expr_rands.at(0);
+        ASSERT(v.get_sort().is_bool(), "Casting a non Boolean formula");
+        return ite(v, c->bv_val(1, 1), c->bv_val(0, 1));
+      }
       default: break;
     }
     ABORT("unkown operator when constructing STP expr");

--- a/dev-clean/headers/llsc/state_imp.hpp
+++ b/dev-clean/headers/llsc/state_imp.hpp
@@ -255,15 +255,19 @@ class PC {
   public:
     PC(std::vector<PtrVal> pc) : pc(std::move(pc)) {}
     PC&& add(PtrVal e) {
-      pc.push_back(e);
+      pc.push_back(SymV::to_cond(e));
       return std::move(*this);
     }
     PC&& add_set(const std::set<PtrVal>& new_pc) {
-      pc.insert(pc.end(), new_pc.begin(), new_pc.end());
+      for (auto&e : new_pc) {
+        pc.push_back(SymV::to_cond(e));
+      }
       return std::move(*this);
     }
     PC&& add_set(const List<PtrVal>& new_pc) {
-      pc.insert(pc.end(), new_pc.begin(), new_pc.end());
+      for (auto&e : new_pc) {
+        pc.push_back(SymV::to_cond(e));
+      }
       return std::move(*this);
     }
     PC&& pop_back() {
@@ -277,7 +281,7 @@ class PC {
     }
     PC&& replace_last_cond(PtrVal e) {
       if (pc.size() == 0) return std::move(*this);
-      pc[pc.size()-1] = e;
+      pc[pc.size()-1] = SymV::to_cond(e);
       return std::move(*this);
     }
     void print() { print_set(pc); }

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -374,8 +374,14 @@ class PC: public Printable {
     List<PtrVal> pc;
   public:
     PC(List<PtrVal> pc) : pc(pc) {}
-    PC add(const PtrVal& e) { return PC(pc.push_back(e)); }
-    PC add_set(List<PtrVal> new_pc) { return PC(pc + new_pc); }
+    PC add(const PtrVal& e) { return PC(pc.push_back(SymV::to_cond(e))); }
+    PC add_set(List<PtrVal> new_pc) {
+      auto temp_pc = pc;
+      for (auto&e : new_pc) {
+        temp_pc = temp_pc.push_back(SymV::to_cond(e));
+      }
+      return PC(temp_pc);
+    }
     List<PtrVal> get_path_conds() { return pc; }
     PtrVal get_last_cond() {
       if (pc.size() > 0) return pc.back();

--- a/dev-clean/headers/llsc/state_tsnt.hpp
+++ b/dev-clean/headers/llsc/state_tsnt.hpp
@@ -261,12 +261,12 @@ class PC {
     PC(TrList<PtrVal> pc) : pc(std::move(pc)) {}
   //PC(const PC& pc) : pc(((PC&)pc).pc.persistent().transient()) {}
     PC&& add(PtrVal e) {
-      pc.push_back(e);
+      pc.push_back(SymV::to_cond(e));
       return std::move(*this);
     }
     PC&& add_set(const List<PtrVal>& new_pc) {
       for (auto& it : new_pc) {
-	pc.push_back(it);
+	      pc.push_back(SymV::to_cond(it));
       }
       return std::move(*this);
     }
@@ -281,7 +281,7 @@ class PC {
     }
     PC&& replace_last_cond(PtrVal e) {
       if (pc.size() == 0) return std::move(*this);
-      pc.set(pc.size()-1, e);
+      pc.set(pc.size()-1, SymV::to_cond(e));
       return std::move(*this);
     }
     void print() { print_set(pc); }

--- a/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
+++ b/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
@@ -51,6 +51,7 @@ object Benchmarks {
   lazy val trunc = parseFile("benchmarks/llvm/trunc.ll")
   lazy val floatArith = parseFile("benchmarks/llvm/floatArith.ll")
   lazy val floatFp80 = parseFile("benchmarks/llvm/floatFp80.ll")
+  lazy val i1Bitvector = parseFile("benchmarks/llvm/i1_bitvector.ll")
 
   lazy val runCommandLine = parseFile("benchmarks/llvm/runCommandLine.ll")
 

--- a/dev-clean/src/test/scala/sai/llsc/TestCases.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestCases.scala
@@ -95,6 +95,7 @@ object TestCases {
     TestPrg(branch2, "branch2", "@f", symArg(2), noOpt, nPath(4)),
     TestPrg(branch3, "branch3", "@f", symArg(2), noOpt, nPath(4)),
     TestPrg(switchTestSym, "switchSymTest", "@main", noArg, noOpt, nPath(5)),
+    TestPrg(i1Bitvector, "i1Bitvector", "@main", noArg, noOpt, nPath(5)++status(0)),
   )
 
   val symbolicSmall: List[TestPrg] = List(


### PR DESCRIPTION
* unifying representattion for i1 type, i1 will be represented by a bitvector of length 1. Boolean formula will only be generated when a
SymV is used as path condition.
int_op_2 will only return bitvector for all operations.

* Add support for zero extend in stp backend.