### PR TITLE
Add get_value to get a feasible assignment of a symbolic expression

### DIFF
--- a/dev-clean/benchmarks/llvm/pointer_sym_off.c
+++ b/dev-clean/benchmarks/llvm/pointer_sym_off.c
@@ -1,0 +1,12 @@
+#include "../../headers/llsc_client.h"
+
+int main() {
+    int nums[] = {0,1,2,3,4};
+    int * p_int = (int *)nums;
+    int idx;
+    make_symbolic(&idx, 4);
+    llsc_assume(idx != 3);
+
+    sym_print(p_int[idx]);
+    return 0;
+}

--- a/dev-clean/benchmarks/llvm/pointer_sym_off.c
+++ b/dev-clean/benchmarks/llvm/pointer_sym_off.c
@@ -2,10 +2,10 @@
 
 int main() {
     int nums[] = {0,1,2,3,4};
-    int * p_int = (int *)nums;
+    int * p_int = (int *)nums + 2;
     int idx;
     make_symbolic(&idx, 4);
-    llsc_assume(idx != 3);
+    llsc_assume(idx != 1);
 
     sym_print(p_int[idx]);
     return 0;

--- a/dev-clean/headers/llsc/auxiliary.hpp
+++ b/dev-clean/headers/llsc/auxiliary.hpp
@@ -14,6 +14,7 @@ using BlockLabel = int;
 using Id = int;
 using Addr = unsigned int;
 using IntData = int64_t;
+using UIntData = unsigned long long int;
 using Fd = int;
 using status_t = unsigned short;
 

--- a/dev-clean/headers/llsc/branch.hpp
+++ b/dev-clean/headers/llsc/branch.hpp
@@ -78,6 +78,7 @@ sym_exec_br_k(SS ss, PtrVal t_cond, PtrVal f_cond,
   }
 }
 
+// Todo : check offset out of bound
 inline immer::flex_vector<std::pair<SS, PtrVal>>
 array_lookup(SS ss, PtrVal base, PtrVal offset, size_t esize) {
   immer::flex_vector_transient<std::pair<SS, PtrVal>> tmp;
@@ -88,14 +89,22 @@ array_lookup(SS ss, PtrVal base, PtrVal offset, size_t esize) {
   }
   else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;
-    for (int newl = (baseloc->l - baseloc->base) % esize + baseloc->base;
-         newl + esize <= baseloc->base + baseloc->size; newl += esize) {
-      auto cond = int_op_2(iOP::op_eq, offset, make_IntV((newl - baseloc->l) / esize, offset->get_bw()));
-      auto ss2 = ss.add_PC(cond);
-      if (check_pc(ss2.get_PC())) {
-        cnt++;
-        tmp.push_back(std::make_pair(ss2, baseloc + (newl - baseloc->l)));
-      }
+    int low_bound = ((int)(baseloc->base - baseloc->l)) / esize;
+    int high_bound = ((int)(baseloc->base + baseloc->size - baseloc->l)) / esize - 1;
+    assert(high_bound >= low_bound);
+    int possible_num = (high_bound - low_bound) + 1;
+
+    auto low_cond = int_op_2(iOP::op_sge, offset, make_IntV(low_bound, offset->get_bw()));
+    auto high_cond = int_op_2(iOP::op_sle, offset, make_IntV(high_bound, offset->get_bw()));
+    auto ss2 = ss.add_PC(low_cond).add_PC(high_cond);
+    auto res = get_value(ss2.get_PC(), offsym);
+    while (res.first) {
+      cnt++;
+      UIntData offset_val = res.second;
+      auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
+      tmp.push_back(std::make_pair(ss.add_PC(t_cond), baseloc + (offset_val*esize)));
+      ss2 = ss2.add_PC(SymV::neg(t_cond));
+      res = get_value(ss2.get_PC(), offsym);
     }
     assert(cnt > 0);
     cov().inc_path(cnt - 1);
@@ -115,19 +124,28 @@ array_lookup_k(SS ss, PtrVal base, PtrVal offset, size_t esize,
   }
   else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;
-    for (int newl = (baseloc->l - baseloc->base) % esize + baseloc->base;
-         newl + esize <= baseloc->base + baseloc->size; newl += esize) {
-      auto cond = int_op_2(iOP::op_eq, offset, make_IntV((newl - baseloc->l) / esize, offset->get_bw()));
-      auto ss2 = ss.add_PC(cond);
-      if (check_pc(ss2.get_PC())) {
-        cnt++;
-        auto addr = baseloc + (newl - baseloc->l);
-        if (can_par_tp()) {
-          tp.add_task([addr=std::move(addr), ss2=std::move(ss2), k]{ return k(ss2, addr); });
-        } else {
-          k(ss2, addr);
-        }
+    int low_bound = ((int)(baseloc->base - baseloc->l)) / esize;
+    int high_bound = ((int)(baseloc->base + baseloc->size - baseloc->l)) / esize - 1;
+    assert(high_bound >= low_bound);
+    int possible_num = (high_bound - low_bound) + 1;
+
+    auto low_cond = int_op_2(iOP::op_sge, offset, make_IntV(low_bound, offset->get_bw()));
+    auto high_cond = int_op_2(iOP::op_sle, offset, make_IntV(high_bound, offset->get_bw()));
+    auto ss2 = ss.add_PC(low_cond).add_PC(high_cond);
+    auto res = get_value(ss2.get_PC(), offsym);
+    while (res.first) {
+      cnt++;
+      UIntData offset_val = res.second;
+      auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
+      auto new_loc = baseloc + (offset_val*esize);
+      auto new_ss = ss.add_PC(t_cond);
+      if (can_par_tp()) {
+        tp.add_task([new_loc=std::move(new_loc), new_ss=std::move(new_ss), k]{ return k(new_ss, new_loc); });
+      } else {
+        k(new_ss, new_loc);
       }
+      ss2 = ss2.add_PC(SymV::neg(t_cond));
+      res = get_value(ss2.get_PC(), offsym);
     }
     assert(cnt > 0);
     cov().inc_path(cnt - 1);
@@ -269,14 +287,22 @@ array_lookup(SS& ss, PtrVal base, PtrVal offset, size_t esize) {
   }
   else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;
-    for (int newl = (baseloc->l - baseloc->base) % esize + baseloc->base;
-         newl + esize <= baseloc->base + baseloc->size; newl += esize) {
-      auto cond = int_op_2(iOP::op_eq, offset, make_IntV((newl - baseloc->l) / esize, offset->get_bw()));
-      auto ss2 = ss.copy().add_PC(cond);
-      if (check_pc(ss2.get_PC())) {
-        cnt++;
-        tmp.push_back(std::make_pair(std::move(ss2), baseloc + (newl - baseloc->l)));
-      }
+    int low_bound = ((int)(baseloc->base - baseloc->l)) / esize;
+    int high_bound = ((int)(baseloc->base + baseloc->size - baseloc->l)) / esize - 1;
+    assert(high_bound >= low_bound);
+    int possible_num = (high_bound - low_bound) + 1;
+
+    auto low_cond = int_op_2(iOP::op_sge, offset, make_IntV(low_bound, offset->get_bw()));
+    auto high_cond = int_op_2(iOP::op_sle, offset, make_IntV(high_bound, offset->get_bw()));
+    auto ss2 = ss.copy().add_PC(low_cond).add_PC(high_cond);
+    auto res = get_value(ss2.get_PC(), offsym);
+    while (res.first) {
+      cnt++;
+      UIntData offset_val = res.second;
+      auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
+      tmp.push_back(std::make_pair(std::move(ss.copy().add_PC(t_cond)), baseloc + (offset_val*esize)));
+      ss2.add_PC(SymV::neg(t_cond));
+      res = get_value(ss2.get_PC(), offsym);
     }
     assert(cnt > 0);
     cov().inc_path(cnt - 1);
@@ -296,14 +322,28 @@ array_lookup_k(SS& ss, PtrVal base, PtrVal offset, size_t esize,
   }
   else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;
-    for (int newl = (baseloc->l - baseloc->base) % esize + baseloc->base;
-         newl + esize <= baseloc->base + baseloc->size; newl += esize) {
-      auto cond = int_op_2(iOP::op_eq, offset, make_IntV((newl - baseloc->l) / esize, offset->get_bw()));
-      auto ss2 = ss.copy().add_PC(cond);
-      if (check_pc(ss2.get_PC())) {
-        cnt++;
-        k(ss2, baseloc + (newl - baseloc->l));
+    int low_bound = ((int)(baseloc->base - baseloc->l)) / esize;
+    int high_bound = ((int)(baseloc->base + baseloc->size - baseloc->l)) / esize - 1;
+    assert(high_bound >= low_bound);
+    int possible_num = (high_bound - low_bound) + 1;
+
+    auto low_cond = int_op_2(iOP::op_sge, offset, make_IntV(low_bound, offset->get_bw()));
+    auto high_cond = int_op_2(iOP::op_sle, offset, make_IntV(high_bound, offset->get_bw()));
+    auto ss2 = ss.copy().add_PC(low_cond).add_PC(high_cond);
+    auto res = get_value(ss2.get_PC(), offsym);
+    while (res.first) {
+      cnt++;
+      UIntData offset_val = res.second;
+      auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
+      auto new_loc = baseloc + (offset_val*esize);
+      auto new_ss = ss.copy().add_PC(t_cond);
+      if (can_par_tp()) {
+        tp.add_task([new_loc=std::move(new_loc), new_ss=std::move(new_ss), k]{ return k((SS&)new_ss, new_loc); });
+      } else {
+        k(new_ss, new_loc);
       }
+      ss2.add_PC(SymV::neg(t_cond));
+      res = get_value(ss2.get_PC(), offsym);
     }
     assert(cnt > 0);
     cov().inc_path(cnt - 1);

--- a/dev-clean/headers/llsc/branch.hpp
+++ b/dev-clean/headers/llsc/branch.hpp
@@ -100,7 +100,7 @@ array_lookup(SS ss, PtrVal base, PtrVal offset, size_t esize) {
     auto res = get_value(ss2.get_PC(), offsym);
     while (res.first) {
       cnt++;
-      UIntData offset_val = res.second;
+      int offset_val = res.second;
       auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
       tmp.push_back(std::make_pair(ss.add_PC(t_cond), baseloc + (offset_val*esize)));
       ss2 = ss2.add_PC(SymV::neg(t_cond));
@@ -135,7 +135,7 @@ array_lookup_k(SS ss, PtrVal base, PtrVal offset, size_t esize,
     auto res = get_value(ss2.get_PC(), offsym);
     while (res.first) {
       cnt++;
-      UIntData offset_val = res.second;
+      int offset_val = res.second;
       auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
       auto new_loc = baseloc + (offset_val*esize);
       auto new_ss = ss.add_PC(t_cond);
@@ -298,7 +298,7 @@ array_lookup(SS& ss, PtrVal base, PtrVal offset, size_t esize) {
     auto res = get_value(ss2.get_PC(), offsym);
     while (res.first) {
       cnt++;
-      UIntData offset_val = res.second;
+      int offset_val = res.second;
       auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
       tmp.push_back(std::make_pair(std::move(ss.copy().add_PC(t_cond)), baseloc + (offset_val*esize)));
       ss2.add_PC(SymV::neg(t_cond));
@@ -333,7 +333,7 @@ array_lookup_k(SS& ss, PtrVal base, PtrVal offset, size_t esize,
     auto res = get_value(ss2.get_PC(), offsym);
     while (res.first) {
       cnt++;
-      UIntData offset_val = res.second;
+      int offset_val = res.second;
       auto t_cond = int_op_2(iOP::op_eq, offset, make_IntV(offset_val, offset->get_bw()));
       auto new_loc = baseloc + (offset_val*esize);
       auto new_ss = ss.copy().add_PC(t_cond);

--- a/dev-clean/headers/llsc/smt_checker.hpp
+++ b/dev-clean/headers/llsc/smt_checker.hpp
@@ -18,6 +18,7 @@ public:
   virtual void init_solvers() = 0;
   virtual void destroy_solvers() = 0;
   virtual solver_result make_query(PC pc) = 0;
+  virtual std::pair<bool, UIntData> get_valid_value(PC pcobj, PtrVal v) = 0;
   virtual void push() = 0;
   virtual void pop() = 0;
   virtual void reset() = 0;
@@ -30,6 +31,12 @@ public:
     auto r = make_query(std::move(pc));
     pop();
     return r == sat;
+  }
+  std::pair<bool, UIntData> get_value(PC pc, PtrVal v) {
+    push();
+    auto r = get_valid_value(std::move(pc), v);
+    pop();
+    return r;
   }
   void generate_test(PC pc) {
     if (!use_solver) return;
@@ -77,5 +84,6 @@ inline Checker& get_checker() {
 
 inline bool check_pc(PC pc) { return get_checker().check_pc(std::move(pc)); }
 inline void check_pc_to_file(SS state) { get_checker().generate_test(std::move(state.get_PC())); }
+inline std::pair<bool, UIntData> get_value(PC pc, PtrVal v) { return get_checker().get_value(std::move(pc), v); }
 
 #endif

--- a/dev-clean/headers/llsc/smt_z3.hpp
+++ b/dev-clean/headers/llsc/smt_z3.hpp
@@ -50,6 +50,21 @@ public:
     solver_time += duration_cast<microseconds>(end - start);
     return (solver_result) result;
   }
+  std::pair<bool, UIntData> get_valid_value(PC pcobj, PtrVal v) override {
+    context* c; solver* s;
+    std::tie(c, s) = get_my_thread_local_instance();
+    auto val = construct_z3_expr(c, v);
+    auto result = make_query(pcobj);
+
+    UIntData ret_val = 0;
+
+    if (solver_result::sat == result) {
+      auto const_val = s->get_model().eval(val, true);
+      ret_val = const_val.get_numeral_uint64();
+    }
+
+    return std::make_pair(solver_result::sat == result, ret_val);
+  }
   expr construct_z3_expr(context* c, PtrVal e) {
     auto int_e = std::dynamic_pointer_cast<IntV>(e);
     if (int_e) {

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -273,8 +273,8 @@ public:
   }
 };
 
-using Mem = MemIdxShadow;
-/* using Mem = MemShadow; */
+//using Mem = MemIdxShadow;
+using Mem = MemShadow;
 
 class Frame: public Printable {
   public:

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -3,11 +3,14 @@
 
 struct Value;
 struct IntV;
+struct SymV;
 struct SS;
+class PC;
 
 using PtrVal = std::shared_ptr<Value>;
 inline PtrVal bv_extract(const PtrVal& v1, int hi, int lo);
 inline PtrVal make_IntV(IntData i, int bw=bitwidth, bool toMSB=true);
+inline std::pair<bool, UIntData> get_value(PC pc, PtrVal v);
 
 /* Value representations */
 

--- a/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
+++ b/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
@@ -37,6 +37,7 @@ object Benchmarks {
   lazy val heapFunptr = parseFile("benchmarks/llvm/heapFunptr.ll")
   lazy val nastyStruct = parseFile("benchmarks/llvm/nastystruct.ll")
   lazy val arrayFlow = parseFile("benchmarks/llvm/arrayflow.ll")
+  lazy val pointerSymOff = parseFile("benchmarks/llvm/pointer_sym_off.ll")
 
   lazy val sp1 = parseFile("benchmarks/llvm/single_path.ll")
   lazy val sp2 = parseFile("benchmarks/llvm/single_path2.ll")

--- a/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/CPSEngine.scala
@@ -124,6 +124,12 @@ trait ImpCPSLLSCEngine extends ImpSymExeDefs with EngineBase {
             val offset = eval(LocalId(x), iTy, ss)
             ss.arrayLookup(base, offset, getTySize(ety),
                            fun { case (s, v) => k(s, v) })
+          case (PtrType(ety, _),
+                TypedValue(iTy, LocalId(x))::Nil) =>
+            val base = eval(ptrValue, ptrType, ss)
+            val offset = eval(LocalId(x), iTy, ss)
+            ss.arrayLookup(base, offset, getTySize(ety),
+                           fun { case (s, v) => k(s, v) })
           case _ =>
             val indexLLVMValue = typedValues.map(tv => tv.value)
             val vs = indexLLVMValue.map(v => eval(v, IntType(32), ss))

--- a/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/Engine.scala
@@ -153,6 +153,14 @@ trait LLSCEngine extends StagedNondet with SymExeDefs with EngineBase {
               ss <- getState
               v <- reflect(ss.arrayLookup(base, offset, getTySize(ety)))
             } yield v
+          case (PtrType(ety, _),
+                TypedValue(iTy, LocalId(x))::Nil) =>
+            for {
+              base <- eval(ptrValue, ptrType)
+              offset <- eval(LocalId(x), iTy)
+              ss <- getState
+              v <- reflect(ss.arrayLookup(base, offset, getTySize(ety)))
+            } yield v
           case _ =>
             val indexLLVMValue = typedValues.map(tv => tv.value)
             for {

--- a/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/ImpEngine.scala
@@ -125,6 +125,13 @@ trait ImpLLSCEngine extends ImpSymExeDefs with EngineBase {
             ss.arrayLookup(base, offset, getTySize(ety)).flatMap { case sv =>
               k(sv._1, sv._2)
             }
+          case (PtrType(ety, _),
+                TypedValue(iTy, LocalId(x))::Nil) =>
+            val base = eval(ptrValue, ptrType, ss)
+            val offset = eval(LocalId(x), iTy, ss)
+            ss.arrayLookup(base, offset, getTySize(ety)).flatMap { case sv =>
+              k(sv._1, sv._2)
+            }
           case _ =>
             val indexLLVMValue = typedValues.map(tv => tv.value)
             val vs = indexLLVMValue.map(v => eval(v, IntType(32), ss))

--- a/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
+++ b/dev-clean/src/main/scala/sai/llsc/engines/PureCPSEngine.scala
@@ -140,6 +140,11 @@ trait PureCPSLLSCEngine extends SymExeDefs with EngineBase {
             val base = eval(ptrValue, ptrType, ss)
             val offset = eval(LocalId(x), iTy, ss)
             ss.arrayLookup(base, offset, getTySize(ety), fun(k))
+          case (PtrType(ety, _),
+                TypedValue(iTy, LocalId(x))::Nil) =>
+            val base = eval(ptrValue, ptrType, ss)
+            val offset = eval(LocalId(x), iTy, ss)
+            ss.arrayLookup(base, offset, getTySize(ety), fun(k))
           case _ =>
             val indexLLVMValue = typedValues.map(tv => tv.value)
             val vs = indexLLVMValue.map(v => eval(v, IntType(32), ss))

--- a/dev-clean/src/test/scala/sai/llsc/TestCases.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestCases.scala
@@ -75,6 +75,7 @@ object TestCases {
     TestPrg(flexAddr, "flexAddr", "@main", noArg, noOpt, nPath(1)++status(0)),
     TestPrg(nastyStruct, "nastyStruct", "@main", noArg, noOpt, nPath(1)++status(0)),
     TestPrg(arrayFlow, "arrayFlow", "@main", noArg, noOpt, nPath(15)++status(0)),
+    TestPrg(pointerSymOff, "pointerSymOff", "@main", noArg, noOpt, nPath(4)++status(0)),
   )
 
   val argv: List[TestPrg] = List(


### PR DESCRIPTION
* Add api (get_value) for get a feasible assignment of a symbolic expression.

* Rewrite array_lookup using get_value.

* Support pointer with symbolic offset in getelementptr.

* Add corresponding testcase.