### PR TITLE
add external functions for coreutils and bug-fix

### DIFF
--- a/dev-clean/benchmarks/llvm/get_value.c
+++ b/dev-clean/benchmarks/llvm/get_value.c
@@ -1,0 +1,23 @@
+#include "../../headers/llsc_client.h"
+#include <stdio.h>
+
+int main() {
+  long x;
+  make_symbolic_whole(&x, sizeof(long));
+  llsc_assume(x > 10);
+  llsc_assume(x < 20);
+
+  llsc_assert_eager(!llsc_is_symbolic(llsc_get_valuel(x)));
+  llsc_assert_eager(llsc_get_valuel(x) > 10);
+  llsc_assert_eager(llsc_get_valuel(x) < 20);
+
+  llsc_assume(x > 18);
+  long x1 = llsc_get_valuel(x + 1);
+  long x0 = llsc_get_valuel(x);
+  llsc_assert_eager(!llsc_is_symbolic(x1));
+  llsc_assert_eager(!llsc_is_symbolic(x0));
+  llsc_assert_eager(20 == x1);
+  llsc_assert_eager(19 == x0);
+
+  return 0;
+}

--- a/dev-clean/headers/llsc/branch.hpp
+++ b/dev-clean/headers/llsc/branch.hpp
@@ -93,7 +93,8 @@ array_lookup(SS ss, PtrVal base, PtrVal offset, size_t esize) {
   auto baseloc = std::dynamic_pointer_cast<LocV>(base);
 
   if (auto offint = std::dynamic_pointer_cast<IntV>(offset)) {
-    result.push_back(std::make_pair(ss, baseloc + offint->as_signed() * esize));
+    // base may not be a locv, ie a bad pointer
+    result.push_back(std::make_pair(ss, base + (offint->as_signed() * esize)));
   } else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;
     int lower_bound = ((int)(baseloc->base - baseloc->l)) / esize;
@@ -126,7 +127,8 @@ array_lookup_k(SS ss, PtrVal base, PtrVal offset, size_t esize,
   auto baseloc = std::dynamic_pointer_cast<LocV>(base);
 
   if (auto offint = std::dynamic_pointer_cast<IntV>(offset)) {
-    k(ss, baseloc + offint->as_signed() * esize);
+    // base may not be a locv, ie a bad pointer
+    k(ss, base + (offint->as_signed() * esize));
   }
   else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;
@@ -298,7 +300,8 @@ array_lookup(SS& ss, PtrVal base, PtrVal offset, size_t esize) {
   auto baseloc = std::dynamic_pointer_cast<LocV>(base);
 
   if (auto offint = std::dynamic_pointer_cast<IntV>(offset)) {
-    result.push_back(std::make_pair(std::move(ss), baseloc + offint->as_signed() * esize));
+    // base may not be a locv, ie a bad pointer
+    result.push_back(std::make_pair(std::move(ss), base + (offint->as_signed() * esize)));
   } else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;
     int lower_bound = ((int)(baseloc->base - baseloc->l)) / esize;
@@ -331,7 +334,8 @@ array_lookup_k(SS& ss, PtrVal base, PtrVal offset, size_t esize,
   auto baseloc = std::dynamic_pointer_cast<LocV>(base);
 
   if (auto offint = std::dynamic_pointer_cast<IntV>(offset)) {
-    k(ss, baseloc + offint->as_signed() * esize);
+    // base may not be a locv, ie a bad pointer
+    k(ss, base + (offint->as_signed() * esize));
   }
   else if (auto offsym = std::dynamic_pointer_cast<SymV>(offset)) {
     int cnt = 0;

--- a/dev-clean/headers/llsc_client.h
+++ b/dev-clean/headers/llsc_client.h
@@ -2,6 +2,7 @@
 #define LLSC_CLIENT_HEADERS
 
 #include <stdio.h>
+#include "stdint.h"
 #include <stddef.h>
 #include <stdbool.h>
 
@@ -67,6 +68,12 @@ static inline void llsc_warning(const char *message) {
 }
 
 #define llsc_warning_once(message) llsc_warning(message)
+
+/* return whether n is a symbolic value */
+unsigned llsc_is_symbolic(uintptr_t n);
+
+/* return a feasible concrete value of expr */
+long llsc_get_valuel(long expr);
 
 /* Support for runing test-comp examples */
 

--- a/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
+++ b/dev-clean/src/main/scala/sai/lang/Benchmarks.scala
@@ -38,6 +38,7 @@ object Benchmarks {
   lazy val nastyStruct = parseFile("benchmarks/llvm/nastystruct.ll")
   lazy val arrayFlow = parseFile("benchmarks/llvm/arrayflow.ll")
   lazy val pointerSymOff = parseFile("benchmarks/llvm/pointer_sym_off.ll")
+  lazy val getValue = parseFile("benchmarks/llvm/get_value.ll")
 
   lazy val sp1 = parseFile("benchmarks/llvm/single_path.ll")
   lazy val sp2 = parseFile("benchmarks/llvm/single_path2.ll")

--- a/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/GenericDefs.scala
@@ -87,11 +87,11 @@ trait Opaques { self: SAIOps with BasicDefs =>
       "llsc_assert", "llsc_assert_eager", "__assert_fail", "sym_exit",
       "make_symbolic", "make_symbolic_whole",
       "stop", "syscall", "llsc_assume",
-      "__errno_location", "_exit", "abort", "calloc"
+      "__errno_location", "_exit", "abort", "calloc", "llsc_is_symbolic", "llsc_get_valuel", "getpagesize", "memalign"
     )
     private val syscalls = MutableSet[String](
       "open", "close", "read", "write", "lseek", "stat", "mkdir", "rmdir", "creat", "unlink", "chmod", "chown"
-    ) 
+    )
     val rederict = scala.collection.immutable.Set[String]("@memcpy", "@memset", "@memmove")
     def apply(f: String, ret: Option[LLVMType] = None): Rep[Value] = {
       if (!used.contains(f)) {

--- a/dev-clean/src/main/scala/sai/llsc/states/ImpSymExeState.scala
+++ b/dev-clean/src/main/scala/sai/llsc/states/ImpSymExeState.scala
@@ -112,7 +112,8 @@ trait ImpSymExeDefs extends SAIOps with BasicDefs with ValueDefs with Opaques wi
     def stackSize: Rep[Int] = reflectRead[Int]("ss-stack-size", ss)(ss)
     def freshStackAddr: Rep[Addr] = stackSize
 
-    def push: Rep[Unit] = reflectWrite[Unit]("ss-push", ss)(ss)
+    // push before function call could be DCE-ed, due to high-level function dependency issue.
+    def push: Rep[Unit] = reflectWrite[Unit]("ss-push", ss)(ss, Adapter.CTRL)
     // XXX: since pop is used in a map, will be DCE-ed if no CTRL
     def pop(keep: Rep[Int]): Rep[Unit] = reflectWrite[Unit]("ss-pop", ss, keep)(ss, Adapter.CTRL)
     def addPC(e: Rep[SMTBool]): Rep[Unit] = reflectWrite[Unit]("ss-addpc", ss, e)(ss)

--- a/dev-clean/src/test/scala/sai/llsc/TestCases.scala
+++ b/dev-clean/src/test/scala/sai/llsc/TestCases.scala
@@ -122,6 +122,7 @@ object TestCases {
     TestPrg(assertTest, "assertTest", "@main", noArg, noOpt, minPath(3)),
     TestPrg(assertfixTest, "assertfix", "@main", noArg, noOpt, nPath(4)),
     TestPrg(assumeTest, "assumeTest", "@main", noArg, noOpt, nPath(1)++status(0)),
+    TestPrg(getValue, "getValue", "@main", noArg, noOpt, nPath(1)++status(0)),
   )
 
   val filesys: List[TestPrg] = List(


### PR DESCRIPTION
* fix : add CTRL write effect to push, avoid being DCE-ed due to high-level function dependency issue.
* add syscall to imperative engine.
* add external: llsc_is_symbolic, llsc_get_valuel, getpagesize, memalign.
* set the default value of un-initialized variable to zero.