### PR TITLE
Use simple pointers for PtrVal

### DIFF
--- a/dev-clean/headers/llsc.hpp
+++ b/dev-clean/headers/llsc.hpp
@@ -32,6 +32,7 @@
 
 #include <sai.hpp>
 #include <immer/flex_vector_transient.hpp>
+#include <immer/array.hpp>
 #include <parallel_hashmap/phmap.h>
 
 using namespace std::chrono;

--- a/dev-clean/headers/llsc/external_shared.hpp
+++ b/dev-clean/headers/llsc/external_shared.hpp
@@ -39,7 +39,7 @@ inline std::monostate noop(SS state, List<PtrVal> args, Cont k) {
 /******************************************************************************/
 
 inline char proj_IntV_char(const PtrVal& v) {
-  std::shared_ptr<IntV> intV = v->to_IntV();
+  auto intV = v->to_IntV();
   ASSERT(intV->get_bw() == 8, "proj_IntV_char: Bitwidth mismatch");
   return static_cast<char>(proj_IntV(intV));
 }

--- a/dev-clean/headers/llsc/smt_checker.hpp
+++ b/dev-clean/headers/llsc/smt_checker.hpp
@@ -52,11 +52,11 @@ class CachedChecker : public Checker {
   }
 
 public:
-  using VarMap = std::map<std::shared_ptr<SymV>, Expr>;
+  using VarMap = std::map<simple_ptr<SymV>, Expr>;
   using ExprDetail = std::tuple<Expr, std::shared_ptr<VarMap>>;
   std::map<PtrVal, ExprDetail> objcache;
 
-  using Model = std::map<std::shared_ptr<SymV>, IntData>;
+  using Model = std::map<simple_ptr<SymV>, IntData>;
   using CheckResult = std::tuple<solver_result, std::shared_ptr<Model>>;
   std::map<std::set<PtrVal>, CheckResult> cexcache;
 
@@ -79,7 +79,7 @@ public:
   template <template <typename> typename Cont>
   CheckResult check_model(
         const Cont<PtrVal>& conds,
-        std::shared_ptr<SymV> query_expr=nullptr,
+        simple_ptr<SymV> query_expr=nullptr,
         bool require_model=false) {
 
     push();
@@ -97,7 +97,7 @@ public:
     // constraint independence resolving
     std::set<PtrVal> condset;
     if (use_cons_indep && exprmap.size() > 1) {
-      std::map<std::shared_ptr<SymV>, std::set<PtrVal>> v2q;
+      std::map<simple_ptr<SymV>, std::set<PtrVal>> v2q;
       for (auto& [q, ev]: exprmap) {
         auto& [e, vm] = ev;
         for (auto& [v, v2]: *vm) {

--- a/dev-clean/headers/llsc/smt_checker.hpp
+++ b/dev-clean/headers/llsc/smt_checker.hpp
@@ -230,6 +230,8 @@ public:
   }
 
   Checker& get_checker() {
+    // why would this improve the performance?
+    static std::unique_ptr<Checker> wtf(solver_kind == SolverKind::stp ? static_cast<Checker*>(new CheckerSTP) : static_cast<Checker*>(new CheckerZ3));
     return *(checker_map[std::this_thread::get_id()]);
   }
 };

--- a/dev-clean/headers/llsc/smt_stp.hpp
+++ b/dev-clean/headers/llsc/smt_stp.hpp
@@ -18,7 +18,7 @@ class CheckerSTP : public CachedChecker<CheckerSTP, ExprHandle> {
 public:
   VC vc;
 
-  ExprHandle construct_expr_internal(PtrVal e, VarSet &vars) {
+  ExprHandle construct_expr_internal(PtrVal e, VarMap &vars) {
     auto int_e = std::dynamic_pointer_cast<IntV>(e);
     if (int_e) {
       if (1 == int_e->bw)
@@ -32,7 +32,7 @@ public:
       ASSERT(sym_e->bw > 1, "i1 symv");
       auto name = sym_e->name;
       ExprHandle stp_expr = vc_varExpr(vc, name.c_str(), vc_bvType(vc, sym_e->bw));
-      vars.insert(sym_e);
+      vars.emplace(sym_e, stp_expr);
       return stp_expr;
     }
 

--- a/dev-clean/headers/llsc/smt_stp.hpp
+++ b/dev-clean/headers/llsc/smt_stp.hpp
@@ -18,7 +18,7 @@ class CheckerSTP : public CachedChecker<CheckerSTP, ExprHandle> {
 public:
   VC vc;
 
-  ExprHandle construct_expr_internal(PtrVal e, VarMap &vars) {
+  ExprHandle construct_expr_internal(PtrVal e, VarSet &vars) {
     auto int_e = std::dynamic_pointer_cast<IntV>(e);
     if (int_e) {
       if (1 == int_e->bw)
@@ -32,16 +32,16 @@ public:
       ASSERT(sym_e->bw > 1, "i1 symv");
       auto name = sym_e->name;
       ExprHandle stp_expr = vc_varExpr(vc, name.c_str(), vc_bvType(vc, sym_e->bw));
-      vars.emplace(sym_e, stp_expr);
+      vars.insert(sym_e);
       return stp_expr;
     }
 
     std::vector<ExprHandle> expr_rands;
     int bw = sym_e->bw;
     for (auto e : sym_e->rands) {
-      auto [e2, vm] = construct_expr(e);
+      auto& [e2, vm] = construct_expr(e);
       expr_rands.push_back(e2);
-      vars.insert(vm->begin(), vm->end());
+      vars.insert(vm.begin(), vm.end());
     }
     switch (sym_e->rator) {
     case iOP::op_add:

--- a/dev-clean/headers/llsc/smt_z3.hpp
+++ b/dev-clean/headers/llsc/smt_z3.hpp
@@ -31,7 +31,7 @@ public:
     auto const_val = g_solver->get_model().eval(val, true);
     return const_val.get_numeral_uint64();
   }
-  expr construct_expr_internal(PtrVal e, VarMap &vars) {
+  expr construct_expr_internal(PtrVal e, VarSet &vars) {
     auto c = g_ctx;
     auto int_e = std::dynamic_pointer_cast<IntV>(e);
     if (int_e) {
@@ -44,15 +44,15 @@ public:
     if (!sym_e->name.empty()) {
       ASSERT(sym_e->bw > 1, "i1 symv");
       auto ret = c->bv_const(sym_e->name.c_str(), sym_e->bw);
-      vars.emplace(sym_e, ret);
+      vars.insert(sym_e);
       return ret;
     }
     int bw = sym_e->bw;
     std::vector<expr> expr_rands;
     for (auto& e : sym_e->rands) {
-      auto [e2, vm] = construct_expr(e);
+      auto& [e2, vm] = construct_expr(e);
       expr_rands.push_back(e2);
-      vars.insert(vm->begin(), vm->end());
+      vars.insert(vm.begin(), vm.end());
     }
     switch (sym_e->rator) {
       case iOP::op_add:

--- a/dev-clean/headers/llsc/smt_z3.hpp
+++ b/dev-clean/headers/llsc/smt_z3.hpp
@@ -31,7 +31,7 @@ public:
     auto const_val = g_solver->get_model().eval(val, true);
     return const_val.get_numeral_uint64();
   }
-  expr construct_expr_internal(PtrVal e, VarSet &vars) {
+  expr construct_expr_internal(PtrVal e, VarMap &vars) {
     auto c = g_ctx;
     auto int_e = std::dynamic_pointer_cast<IntV>(e);
     if (int_e) {
@@ -44,7 +44,7 @@ public:
     if (!sym_e->name.empty()) {
       ASSERT(sym_e->bw > 1, "i1 symv");
       auto ret = c->bv_const(sym_e->name.c_str(), sym_e->bw);
-      vars.insert(sym_e);
+      vars.emplace(sym_e, ret);
       return ret;
     }
     int bw = sym_e->bw;

--- a/dev-clean/headers/llsc/state_imp.hpp
+++ b/dev-clean/headers/llsc/state_imp.hpp
@@ -233,7 +233,8 @@ class Stack {
     PtrVal at(size_t idx) { return mem.at(idx); }
     PtrVal at(size_t idx, int size) { return mem.at(idx, size); }
     PtrVal at_struct(size_t idx, int size) {
-      return std::make_shared<StructV>(mem.slice(idx, size).get_mem());
+      auto ret = make_simple<StructV>(mem.slice(idx, size).get_mem());
+      return hashconsing(ret);
     }
     Stack&& update(size_t idx, PtrVal val) {
       mem.update(idx, val);
@@ -331,7 +332,8 @@ class SS {
       auto loc = std::dynamic_pointer_cast<LocV>(addr);
       ASSERT(loc != nullptr, "Lookup an non-address value");
       if (loc->k == LocV::kStack) return stack.at_struct(loc->l, size);
-      return std::make_shared<StructV>(heap.slice(loc->l, size).get_mem());
+      auto ret = make_simple<StructV>(heap.slice(loc->l, size).get_mem());
+      return hashconsing(ret);
     }
     List<PtrVal> at_seq(PtrVal addr, int count) {
       auto s = std::dynamic_pointer_cast<StructV>(at_struct(addr, count));
@@ -475,7 +477,8 @@ inline const List<SSVal> mt_path_result = List<SSVal>{};
 using func_t = List<SSVal> (*)(SS&, List<PtrVal>);
 
 inline PtrVal make_FunV(func_t f) {
-  return std::make_shared<FunV<func_t>>(f);
+  auto ret = make_simple<FunV<func_t>>(f);
+  return hashconsing(ret);
 }
 
 inline List<SSVal> direct_apply(PtrVal v, SS ss, List<PtrVal> args) {
@@ -487,7 +490,8 @@ inline List<SSVal> direct_apply(PtrVal v, SS ss, List<PtrVal> args) {
 using func_cps_t = std::monostate (*)(SS&, List<PtrVal>, std::function<std::monostate(SS&, PtrVal)>);
 
 inline PtrVal make_CPSFunV(func_cps_t f) {
-  return std::make_shared<FunV<func_cps_t>>(f);
+  auto ret = make_simple<FunV<func_cps_t>>(f);
+  return hashconsing(ret);
 }
 
 inline std::monostate cps_apply(PtrVal v, SS ss, List<PtrVal> args, std::function<std::monostate(SS&, PtrVal)> k) {

--- a/dev-clean/headers/llsc/state_pure.hpp
+++ b/dev-clean/headers/llsc/state_pure.hpp
@@ -362,7 +362,8 @@ class Stack: public Printable {
     PtrVal at(size_t idx) { return mem.at(idx); }
     PtrVal at(size_t idx, int size) { return mem.at(idx, size); }
     PtrVal at_struct(size_t idx, int size) {
-      return std::make_shared<StructV>(mem.take(idx + size).drop(idx).get_mem());
+      auto ret = make_simple<StructV>(mem.take(idx + size).drop(idx).get_mem());
+      return hashconsing(ret);
     }
     Stack update(size_t idx, const PtrVal& val) { return Stack(mem.update(idx, val), env, errno_location); }
     Stack update(size_t idx, const PtrVal& val, int size) { return Stack(mem.update(idx, val, size), env, errno_location); }
@@ -430,7 +431,8 @@ class SS: public Printable {
       auto loc = std::dynamic_pointer_cast<LocV>(addr);
       ASSERT(loc != nullptr, "Lookup an non-address value");
       if (loc->k == LocV::kStack) return stack.at_struct(loc->l, size);
-      return std::make_shared<StructV>(heap.take(loc->l + size).drop(loc->l).get_mem());
+      auto ret = make_simple<StructV>(heap.take(loc->l + size).drop(loc->l).get_mem());
+      return hashconsing(ret);
     }
     List<PtrVal> at_seq(const PtrVal& addr, int count) {
       auto s = std::dynamic_pointer_cast<StructV>(at_struct(addr, count));
@@ -517,7 +519,8 @@ inline const List<SSVal> mt_path_result = List<SSVal>{};
 using func_t = List<SSVal> (*)(SS, List<PtrVal>);
 
 inline PtrVal make_FunV(func_t f) {
-  return std::make_shared<FunV<func_t>>(f);
+  auto ret = make_simple<FunV<func_t>>(f);
+  return hashconsing(ret);
 }
 
 inline List<SSVal> direct_apply(const PtrVal& v, const SS& ss, List<PtrVal> args) {
@@ -529,7 +532,8 @@ inline List<SSVal> direct_apply(const PtrVal& v, const SS& ss, List<PtrVal> args
 using func_cps_t = std::monostate (*)(SS, List<PtrVal>, std::function<std::monostate(SS, PtrVal)>);
 
 inline PtrVal make_CPSFunV(func_cps_t f) {
-  return std::make_shared<FunV<func_cps_t>>(f);
+  auto ret = make_simple<FunV<func_cps_t>>(f);
+  return hashconsing(ret);
 }
 
 inline std::monostate cps_apply(const PtrVal& v, const SS& ss, List<PtrVal> args, std::function<std::monostate(SS, PtrVal)> k) {

--- a/dev-clean/headers/llsc/state_tsnt.hpp
+++ b/dev-clean/headers/llsc/state_tsnt.hpp
@@ -238,7 +238,8 @@ class Stack {
     PtrVal at(size_t idx) { return mem.at(idx); }
     PtrVal at(size_t idx, int size) { return mem.at(idx, size); }
     PtrVal at_struct(size_t idx, int size) {
-      return std::make_shared<StructV>(mem.slice(idx, size).get_pmem());
+      auto ret = make_simple<StructV>(mem.slice(idx, size).get_pmem());
+      return hashconsing(ret);
     }
     Stack&& update(size_t idx, PtrVal val) {
       mem.update(idx, val);
@@ -336,7 +337,8 @@ class SS {
       auto loc = std::dynamic_pointer_cast<LocV>(addr);
       ASSERT(loc != nullptr, "Lookup an non-address value");
       if (loc->k == LocV::kStack) return stack.at_struct(loc->l, size);
-      return std::make_shared<StructV>(heap.slice(loc->l, size).get_pmem());
+      auto ret = make_simple<StructV>(heap.slice(loc->l, size).get_pmem());
+      return hashconsing(ret);
     }
     List<PtrVal> at_seq(PtrVal addr, int count) {
       auto s = std::dynamic_pointer_cast<StructV>(at_struct(addr, count));
@@ -474,7 +476,8 @@ inline const List<SSVal> mt_path_result = List<SSVal>{};
 using func_t = List<SSVal> (*)(SS&, List<PtrVal>);
 
 inline PtrVal make_FunV(func_t f) {
-  return std::make_shared<FunV<func_t>>(f);
+  auto ret = make_simple<FunV<func_t>>(f);
+  return hashconsing(ret);
 }
 
 inline List<SSVal> direct_apply(PtrVal v, SS ss, List<PtrVal> args) {
@@ -486,7 +489,8 @@ inline List<SSVal> direct_apply(PtrVal v, SS ss, List<PtrVal> args) {
 using func_cps_t = std::monostate (*)(SS&, List<PtrVal>, std::function<std::monostate(SS&, PtrVal)>);
 
 inline PtrVal make_CPSFunV(func_cps_t f) {
-  return std::make_shared<FunV<func_cps_t>>(f);
+  auto ret = make_simple<FunV<func_cps_t>>(f);
+  return hashconsing(ret);
 }
 
 inline std::monostate cps_apply(PtrVal v, SS ss, List<PtrVal> args, std::function<std::monostate(SS&, PtrVal)> k) {

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -7,19 +7,73 @@ struct SymV;
 struct SS;
 class PC;
 
-using PtrVal = std::shared_ptr<Value>;
+template <typename T>
+class simple_ptr {
+  T *ptr;
+public:
+  simple_ptr(T* p): ptr(p) { }
+  simple_ptr(): simple_ptr(nullptr) { }
+  template<typename U, typename = std::enable_if_t<std::is_base_of_v<T, U>>>
+  simple_ptr(const simple_ptr<U> &rhs): simple_ptr(static_cast<T*>(rhs.get())) { }
+  ~simple_ptr() { }
+  T* get() const { return ptr; }
+  T& operator*() const { return *ptr; }
+  T* operator->() const { return ptr; }
+  explicit operator bool() const { return bool(ptr); }
+  bool operator<(const simple_ptr& rhs) const { return ptr < rhs.ptr; }
+  bool operator!=(const simple_ptr& rhs) const { return ptr != rhs.ptr; }
+  bool operator==(const simple_ptr& rhs) const { return ptr == rhs.ptr; }
+};
+
+template <typename T>
+std::ostream& operator<<(std::ostream& outs, const simple_ptr<T>& rhs) {
+  return outs << rhs;
+}
+
+template <typename T>
+struct enable_simple_from_this {
+  simple_ptr<T> shared_from_this() {
+    return static_cast<T*>(this);
+  }
+};
+
+template<typename T, typename... Args>
+simple_ptr<T> make_simple(Args&&... args) {
+  return simple_ptr(new T(std::forward<Args>(args)...));
+}
+
+namespace std {
+template<typename T, typename U>
+simple_ptr<T> dynamic_pointer_cast(simple_ptr<U> v) {
+  return simple_ptr<T>(dynamic_cast<T*>(v.get()));
+}
+
+template<typename T, typename U>
+simple_ptr<T> static_pointer_cast(simple_ptr<U> v) {
+  return simple_ptr<T>(static_cast<T*>(v.get()));
+}
+
+template <typename T>
+struct hash<simple_ptr<T>> {
+  size_t operator()(const simple_ptr<T> &rhs) const noexcept {
+    return hash<T*>(rhs.get());
+  }
+};
+}
+
+using PtrVal = simple_ptr<Value>;
 inline PtrVal bv_extract(const PtrVal& v1, int hi, int lo);
 inline PtrVal make_IntV(IntData i, int bw=default_bw, bool toMSB=true);
 inline std::pair<bool, UIntData> get_sat_value(PC pc, PtrVal v);
 
 /* Value representations */
 
-struct Value : public std::enable_shared_from_this<Value>, public Printable {
+struct Value : public enable_simple_from_this<Value>, public Printable {
   virtual bool is_conc() const = 0;
   virtual int get_bw() const = 0;
   size_t get_byte_size() const { return (get_bw() + 7) / 8; }
   virtual bool compare(const Value* v) const = 0;
-  virtual std::shared_ptr<IntV> to_IntV() = 0;
+  virtual simple_ptr<IntV> to_IntV() = 0;
   inline bool operator==(const Value& rhs){ return compare(&rhs); }
 
   /* `to_bytes` produces the memory representation of this value
@@ -110,6 +164,13 @@ inline phmap::parallel_flat_hash_set<PtrVal,
     4,
     std::mutex> objpool;
 
+inline PtrVal hashconsing(const PtrVal &ret) {
+  // if (!use_hashcons) return ret;
+  auto [ret2, ins] = objpool.insert(ret);
+  if (!ins) delete ret.get();
+  return *ret2;
+}
+
 // Uninitialized value
 inline PtrVal make_UinitV() {
   static PtrVal UinitV = make_IntV(0, 8);
@@ -123,14 +184,14 @@ struct ShadowV : public Value {
   virtual bool is_conc() const { return true; };
   virtual int get_bw() const { return 0; }
   virtual bool compare(const Value* v) const { return false; }
-  virtual std::shared_ptr<IntV> to_IntV() { return nullptr; }
+  virtual simple_ptr<IntV> to_IntV() { return nullptr; }
   virtual std::string toString() const { return "❏"; }
   virtual List<PtrVal> to_bytes() { return List<PtrVal>{shared_from_this()}; }
   virtual List<PtrVal> to_bytes_shadow() { return to_bytes(); }
 };
 
 inline PtrVal make_ShadowV() {
-  static PtrVal singleton = std::make_shared<ShadowV>();
+  static PtrVal singleton = make_simple<ShadowV>();
   return singleton;
 }
 
@@ -138,14 +199,14 @@ inline PtrVal make_ShadowV(int8_t offset) {
   ASSERT(-16 < offset && offset < 0, "unexpected ShadowV's offset");
   static PtrVal shadow_vals[16] = {
     nullptr,
-    std::make_shared<ShadowV>(-1),   std::make_shared<ShadowV>(-2),
-    std::make_shared<ShadowV>(-3),   std::make_shared<ShadowV>(-4),
-    std::make_shared<ShadowV>(-5),   std::make_shared<ShadowV>(-6),
-    std::make_shared<ShadowV>(-7),   std::make_shared<ShadowV>(-8),
-    std::make_shared<ShadowV>(-9),   std::make_shared<ShadowV>(-10),
-    std::make_shared<ShadowV>(-11),  std::make_shared<ShadowV>(-12),
-    std::make_shared<ShadowV>(-13),  std::make_shared<ShadowV>(-14),
-    std::make_shared<ShadowV>(-15)
+    make_simple<ShadowV>(-1),   make_simple<ShadowV>(-2),
+    make_simple<ShadowV>(-3),   make_simple<ShadowV>(-4),
+    make_simple<ShadowV>(-5),   make_simple<ShadowV>(-6),
+    make_simple<ShadowV>(-7),   make_simple<ShadowV>(-8),
+    make_simple<ShadowV>(-9),   make_simple<ShadowV>(-10),
+    make_simple<ShadowV>(-11),  make_simple<ShadowV>(-12),
+    make_simple<ShadowV>(-13),  make_simple<ShadowV>(-14),
+    make_simple<ShadowV>(-15)
   };
   return shadow_vals[-offset];
 }
@@ -172,7 +233,7 @@ struct IntV : Value {
     ss << "IntV(" << as_signed() << ", " << bw << ")";
     return ss.str();
   }
-  virtual std::shared_ptr<IntV> to_IntV() override {
+  virtual simple_ptr<IntV> to_IntV() override {
     auto thisptr = shared_from_this();
     return std::static_pointer_cast<IntV>(thisptr);
   }
@@ -202,10 +263,8 @@ struct IntV : Value {
 };
 
 inline PtrVal make_IntV(IntData i, int bw, bool toMSB) {
-  auto ret = std::make_shared<IntV>(toMSB ? (i << (addr_bw - bw)) : i, bw);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<IntV>(toMSB ? (i << (addr_bw - bw)) : i, bw);
+  return hashconsing(ret);
 }
 
 inline IntData proj_IntV(const PtrVal& v) {
@@ -230,7 +289,7 @@ struct FloatV : Value {
     return ss.str();
   }
   virtual bool is_conc() const override { return true; }
-  virtual std::shared_ptr<IntV> to_IntV() override { return nullptr; }
+  virtual simple_ptr<IntV> to_IntV() override { return nullptr; }
   virtual int get_bw() const override { return bw; }
 
   virtual bool compare(const Value* v) const override {
@@ -247,17 +306,13 @@ struct FloatV : Value {
 };
 
 inline PtrVal make_FloatV(long double f) {
-  auto ret = std::make_shared<FloatV>(f);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<FloatV>(f);
+  return hashconsing(ret);
 }
 
 inline PtrVal make_FloatV(long double f, size_t bw) {
-  auto ret = std::make_shared<FloatV>(f, bw);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<FloatV>(f, bw);
+  return hashconsing(ret);
 }
 
 inline PtrVal make_FloatV_fp80(std::array<unsigned char, 10> buf) {
@@ -324,10 +379,8 @@ struct LocV : IntV {
 };
 
 inline PtrVal make_LocV(Addr base, LocV::Kind k, size_t size, size_t off = 0) {
-  auto ret = std::make_shared<LocV>(base, k, size, off);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<LocV>(base, k, size, off);
+  return hashconsing(ret);
 }
 
 inline unsigned int proj_LocV(const PtrVal& v) {
@@ -414,7 +467,7 @@ struct SymV : Value {
     return ss.str();
   }
   virtual bool is_conc() const override { return false; }
-  virtual std::shared_ptr<IntV> to_IntV() override { return nullptr; }
+  virtual simple_ptr<IntV> to_IntV() override { return nullptr; }
   virtual int get_bw() const override { return bw; }
 
   virtual bool compare(const Value* v) const override {
@@ -442,16 +495,16 @@ struct SymV : Value {
     auto arg0 = std::dynamic_pointer_cast<SymV>(rands[0]);
     if (rator == iOP::op_neg && arg0) {
       switch (arg0->rator) {
-        case iOP::op_neq: return std::make_shared<SymV>(iOP::op_eq, arg0->rands, bw);
-        case iOP::op_eq:  return std::make_shared<SymV>(iOP::op_neq, arg0->rands, bw);
-        case iOP::op_sle: return std::make_shared<SymV>(iOP::op_sgt, arg0->rands, bw);
-        case iOP::op_slt: return std::make_shared<SymV>(iOP::op_sge, arg0->rands, bw);
-        case iOP::op_sge: return std::make_shared<SymV>(iOP::op_slt, arg0->rands, bw);
-        case iOP::op_sgt: return std::make_shared<SymV>(iOP::op_sle, arg0->rands, bw);
-        case iOP::op_ule: return std::make_shared<SymV>(iOP::op_ugt, arg0->rands, bw);
-        case iOP::op_ult: return std::make_shared<SymV>(iOP::op_uge, arg0->rands, bw);
-        case iOP::op_uge: return std::make_shared<SymV>(iOP::op_ult, arg0->rands, bw);
-        case iOP::op_ugt: return std::make_shared<SymV>(iOP::op_ule, arg0->rands, bw);
+        case iOP::op_neq: return make_simple<SymV>(iOP::op_eq, arg0->rands, bw);
+        case iOP::op_eq:  return make_simple<SymV>(iOP::op_neq, arg0->rands, bw);
+        case iOP::op_sle: return make_simple<SymV>(iOP::op_sgt, arg0->rands, bw);
+        case iOP::op_slt: return make_simple<SymV>(iOP::op_sge, arg0->rands, bw);
+        case iOP::op_sge: return make_simple<SymV>(iOP::op_slt, arg0->rands, bw);
+        case iOP::op_sgt: return make_simple<SymV>(iOP::op_sle, arg0->rands, bw);
+        case iOP::op_ule: return make_simple<SymV>(iOP::op_ugt, arg0->rands, bw);
+        case iOP::op_ult: return make_simple<SymV>(iOP::op_uge, arg0->rands, bw);
+        case iOP::op_uge: return make_simple<SymV>(iOP::op_ult, arg0->rands, bw);
+        case iOP::op_ugt: return make_simple<SymV>(iOP::op_ule, arg0->rands, bw);
       }
     }
     auto end = steady_clock::now();
@@ -474,17 +527,13 @@ inline std::map<size_t, PtrVal> symv_cache;
 */
 
 inline PtrVal make_SymV(const String& n) {
-  auto ret = std::make_shared<SymV>(n, default_bw);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<SymV>(n, default_bw);
+  return hashconsing(ret);
 }
 
 inline PtrVal make_SymV(String n, size_t bw) {
-  auto ret = std::make_shared<SymV>(n, bw);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<SymV>(n, bw);
+  return hashconsing(ret);
 }
 
 inline PtrVal make_SymV(iOP rator, List<PtrVal> rands, size_t bw) {
@@ -492,10 +541,8 @@ inline PtrVal make_SymV(iOP rator, List<PtrVal> rands, size_t bw) {
   // if (s) {
   //   return s;
   // }
-  auto ret = std::make_shared<SymV>(rator, std::move(rands), bw);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<SymV>(rator, std::move(rands), bw);
+  return hashconsing(ret);
 }
 
 inline List<PtrVal> make_SymV_seq(unsigned length, const std::string& prefix, size_t bw) {
@@ -528,7 +575,7 @@ struct StructV : Value {
   virtual bool is_conc() const override {
     ABORT("is_conc: unexpected value StructV.");
   }
-  virtual std::shared_ptr<IntV> to_IntV() override { return nullptr; }
+  virtual simple_ptr<IntV> to_IntV() override { return nullptr; }
   virtual int get_bw() const override { ABORT("get_bw: unexpected value StructV."); }
 
   virtual bool compare(const Value* v) const override {

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -148,16 +148,6 @@ struct equal_to_PtrVal {
   }
 };
 
-// template<>
-// struct std::equal_to<immer::flex_vector<PtrVal>> {
-//   bool operator()(immer::flex_vector<PtrVal> const& a, immer::flex_vector<PtrVal> const& b) const {
-//     if (a.size() != b.size()) return false;
-//     for (int i = 0; i < a.size(); i++)
-//       if (a.at(i).get() != b.at(i).get()) return false;
-//     return true;
-//   }
-// };
-
 inline phmap::parallel_flat_hash_set<PtrVal,
     hash_PtrVal,
     equal_to_PtrVal,
@@ -479,7 +469,7 @@ struct SymV : Value {
     if (this->bw != that->bw) return false;
     if (this->name != that->name) return false;
     if (this->rator != that->rator) return false;
-    return std::equal_to<decltype(rands)>{}(this->rands, that->rands);
+    return this->rands == that->rands;
   }
   virtual List<PtrVal> to_bytes() {
     if (bw <= 8) return List<PtrVal>{shared_from_this()};
@@ -600,7 +590,7 @@ struct SymLocV : SymV {
 
   virtual bool compare(const Value* v) const override {
     auto that = static_cast<decltype(this)>(v);
-    if (!std::equal_to<PtrVal>{}(this->off, that->off)) return false;
+    if (this->off != that->off) return false;
     if (this->k != that->k) return false;
     if (this->base != that->base) return false;
     return this->size == that->size;
@@ -635,7 +625,7 @@ struct StructV : Value {
 
   virtual bool compare(const Value* v) const override {
     auto that = static_cast<decltype(this)>(v);
-    return std::equal_to<decltype(fs)>{}(this->fs, that->fs);
+    return this->fs == that->fs;
   }
 
   virtual List<PtrVal> to_bytes() { ABORT("???"); }

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -437,13 +437,13 @@ struct SymV : Value {
   String name;
   size_t bw;
   iOP rator;
-  immer::flex_vector<PtrVal> rands;
+  immer::array<PtrVal> rands;
   SymV(String name, size_t bw) : name(name), bw(bw) {
     hash_combine(hash(), std::string("symv1"));
     hash_combine(hash(), name);
     hash_combine(hash(), bw);
   }
-  SymV(iOP rator, immer::flex_vector<PtrVal> rands, size_t bw) : rator(rator), rands(rands), bw(bw) {
+  SymV(iOP rator, immer::array<PtrVal> rands, size_t bw) : rator(rator), rands(rands), bw(bw) {
     hash_combine(hash(), std::string("symv2"));
     hash_combine(hash(), rator);
     hash_combine(hash(), bw);
@@ -534,7 +534,7 @@ inline PtrVal make_SymV(String n, size_t bw) {
   return hashconsing(ret);
 }
 
-inline PtrVal make_SymV(iOP rator, List<PtrVal> rands, size_t bw) {
+inline PtrVal make_SymV(iOP rator, immer::array<PtrVal> rands, size_t bw) {
   // auto s = SymV::simplify(rator, rands, bw);
   // if (s) {
   //   return s;
@@ -552,7 +552,7 @@ inline List<PtrVal> make_SymV_seq(unsigned length, const std::string& prefix, si
 }
 
 inline PtrVal SymV::neg(const PtrVal& v) {
-  return make_SymV(iOP::op_neg, List<PtrVal>({ v }), v->get_bw());
+  return make_SymV(iOP::op_neg, { v }, v->get_bw());
 }
 
 struct StructV : Value {
@@ -671,7 +671,7 @@ inline PtrVal int_op_2(iOP op, const PtrVal& v1, const PtrVal& v2) {
       default:
         break;
     }
-    return make_SymV(op, List<PtrVal>({ v1, v2 }), bw);
+    return make_SymV(op, { v1, v2 }, bw);
   }
 }
 
@@ -743,7 +743,7 @@ inline PtrVal bv_sext(const PtrVal& v, int bw) {
     if (s1) {
       // Note: instead of passing new bw as an operand
       // we override the original bw here
-      return make_SymV(iOP::op_sext, List<PtrVal>({ s1 }), bw);
+      return make_SymV(iOP::op_sext, { s1 }, bw);
     }
     ABORT("Sext an invalid value, exit");
   }
@@ -758,7 +758,7 @@ inline PtrVal bv_zext(const PtrVal& v, int bw) {
     if (s1) {
       // Note: instead of passing new bw as an operand
       // we override the original bw here
-      return make_SymV(iOP::op_zext, List<PtrVal>({ s1 }), bw);
+      return make_SymV(iOP::op_zext, { s1 }, bw);
     }
     ABORT("Zext an invalid value, exit");
   }
@@ -771,7 +771,7 @@ inline PtrVal trunc(const PtrVal& v1, int from, int to) {
   }
   auto s1 = std::dynamic_pointer_cast<SymV>(v1);
   if (s1) {
-    return make_SymV(iOP::op_trunc, List<PtrVal>({ v1 }), to);
+    return make_SymV(iOP::op_trunc, { v1 }, to);
   }
   ABORT("Truncate an invalid value, exit");
 }
@@ -798,7 +798,7 @@ inline PtrVal bv_concat(const PtrVal& v1, const PtrVal& v2) {
   ASSERT(!std::dynamic_pointer_cast<ShadowV>(v1) && !std::dynamic_pointer_cast<ShadowV>(v2),
          "Cannot concat ShadowV values");
   // XXX: also check LocV and FunV?
-  return make_SymV(iOP::op_concat, List<PtrVal>({ v1, v2 }), bw1 + bw2);
+  return make_SymV(iOP::op_concat, { v1, v2 }, bw1 + bw2);
 }
 
 inline const PtrVal IntV0 = make_IntV(0, 64);

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -56,7 +56,7 @@ simple_ptr<T> static_pointer_cast(simple_ptr<U> v) {
 template <typename T>
 struct hash<simple_ptr<T>> {
   size_t operator()(const simple_ptr<T> &rhs) const noexcept {
-    return hash<T*>(rhs.get());
+    return hash<T*>{}(rhs.get());
   }
 };
 }
@@ -130,15 +130,13 @@ struct Value : public enable_simple_from_this<Value>, public Printable {
 
 };
 
-template<>
-struct std::hash<PtrVal> {
+struct hash_PtrVal {
   size_t operator()(PtrVal const& v) const noexcept {
     return v ? v->hash() : std::hash<nullptr_t>{}(nullptr);
   }
 };
 
-template<>
-struct std::equal_to<PtrVal> {
+struct equal_to_PtrVal {
   bool operator()(PtrVal const& a, PtrVal const& b) const {
     if (!a || !b) return a == b;
     if (std::type_index(typeid(*a)) != std::type_index(typeid(*b)))
@@ -147,19 +145,19 @@ struct std::equal_to<PtrVal> {
   }
 };
 
-template<>
-struct std::equal_to<immer::flex_vector<PtrVal>> {
-  bool operator()(immer::flex_vector<PtrVal> const& a, immer::flex_vector<PtrVal> const& b) const {
-    if (a.size() != b.size()) return false;
-    for (int i = 0; i < a.size(); i++)
-      if (a.at(i).get() != b.at(i).get()) return false;
-    return true;
-  }
-};
+// template<>
+// struct std::equal_to<immer::flex_vector<PtrVal>> {
+//   bool operator()(immer::flex_vector<PtrVal> const& a, immer::flex_vector<PtrVal> const& b) const {
+//     if (a.size() != b.size()) return false;
+//     for (int i = 0; i < a.size(); i++)
+//       if (a.at(i).get() != b.at(i).get()) return false;
+//     return true;
+//   }
+// };
 
 inline phmap::parallel_flat_hash_set<PtrVal,
-    std::hash<PtrVal>,
-    std::equal_to<PtrVal>,
+    hash_PtrVal,
+    equal_to_PtrVal,
     std::allocator<PtrVal>,
     4,
     std::mutex> objpool;

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -582,7 +582,7 @@ struct SymLocV : SymV {
   size_t base, size;
 
   SymLocV(Addr base, LocV::Kind k, int size, PtrVal off) :
-    SymV(iOP::op_add, List<PtrVal>({ bv_sext(off, addr_bw), make_IntV((LocV::MemOffset[k] + base), addr_bw) }), addr_bw), off(addr_index_ext(off)), k(k), base(base), size(size) {
+    SymV(iOP::op_add, { bv_sext(off, addr_bw), make_IntV((LocV::MemOffset[k] + base), addr_bw) }, addr_bw), off(addr_index_ext(off)), k(k), base(base), size(size) {
     hash_combine(hash(), std::string("symlocv"));
     hash_combine(hash(), std::hash<PtrVal>{}(off));
     hash_combine(hash(), k);
@@ -608,10 +608,8 @@ struct SymLocV : SymV {
 };
 
 inline PtrVal make_SymLocV(Addr base, LocV::Kind k, size_t size, PtrVal off) {
-  auto ret = std::make_shared<SymLocV>(base, k, size, off);
-  if (!use_hashcons) return ret;
-  auto ins = objpool.insert(ret);
-  return *(ins.first);
+  auto ret = make_simple<SymLocV>(base, k, size, off);
+  return hashconsing(ret);
 }
 
 struct StructV : Value {
@@ -783,7 +781,7 @@ inline PtrVal ite(const PtrVal& cond, const PtrVal& v_t, const PtrVal& v_e) {
     return cond_i->i ? v_t : v_e;
   }
   ASSERT(std::dynamic_pointer_cast<SymV>(cond), "Invalid condition");
-  return make_SymV(iOP::op_ite, List<PtrVal>({ cond, v_t, v_e }), v_t->get_bw());
+  return make_SymV(iOP::op_ite, { cond, v_t, v_e }, v_t->get_bw());
 }
 
 /* TODO: implement those two <2022-03-10, David Deng> */

--- a/dev-clean/headers/llsc/value_ops.hpp
+++ b/dev-clean/headers/llsc/value_ops.hpp
@@ -8,7 +8,7 @@ struct SS;
 class PC;
 
 template <typename T>
-class simple_ptr {
+struct simple_ptr {
   T *ptr;
 public:
   simple_ptr(T* p): ptr(p) { }
@@ -27,7 +27,7 @@ public:
 
 template <typename T>
 std::ostream& operator<<(std::ostream& outs, const simple_ptr<T>& rhs) {
-  return outs << rhs;
+  return outs << rhs.ptr;
 }
 
 template <typename T>

--- a/dev-clean/headers/test/sym_test.cpp
+++ b/dev-clean/headers/test/sym_test.cpp
@@ -48,11 +48,11 @@ int main() {
 	//Value& y = x;
 	//std::cout << y << std::endl;
 
-	std::shared_ptr<Value> z = std::make_shared<IntV>(x);
+	simple_ptr<Value> z = make_simple<IntV>(x);
 	std::cout << *z << std::endl;
 	//std::cout << (*z == x) << std::endl;
 
-	std::cout << *op_2("+", z, std::make_shared<IntV>(x)) << std::endl;
+	std::cout << *op_2("+", z, make_simple<IntV>(x)) << std::endl;
 	
 	BoolV b(true);
 	std::cout << b << std::endl;
@@ -70,8 +70,8 @@ int main() {
 
 	std::cout << *s->args.at(0) << std::endl;
 	
-	auto v = immer::set<std::shared_ptr<Value>>();
-	v = v.insert(std::make_shared<BoolV>(b));
+	auto v = immer::set<simple_ptr<Value>>();
+	v = v.insert(make_simple<BoolV>(b));
 
 	test_set();
 


### PR DESCRIPTION
Given that hash consing is in use, PtrVal won't be shared in fact, and thus we can simply use simple pointers, eliminating the ref-counting overhead.